### PR TITLE
Added a centralised db settings file which can be included if it exists

### DIFF
--- a/vlad/playbooks/roles/php/tasks/drupal_install.yml
+++ b/vlad/playbooks/roles/php/tasks/drupal_install.yml
@@ -18,3 +18,8 @@
   command: chmod +x /var/www/drupal8_install.sh
   tags: drupalinstall
   sudo: true
+
+- name: Drush | copy database settings file
+  template: src=drupal/vlad-db-settings.j2 dest=/var/www/vlad-db-settings.inc
+  tags: drupalinstall
+  sudo: true

--- a/vlad/playbooks/roles/php/templates/drupal/vlad-db-settings.j2
+++ b/vlad/playbooks/roles/php/templates/drupal/vlad-db-settings.j2
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Database settings file.
+ */
+
+if (!isset($databases)) {
+  $databases = array();
+}
+
+$databases['default']['default'] = array(
+  'driver' => 'mysql',
+  'database' => '{{ dbname }}',
+  'username' => '{{ dbuser }}',
+  'password' => '{{ dbpass }}',
+  'host' => '127.0.0.1',
+  'port' => 3306,
+);


### PR DESCRIPTION
Suggestion to add a centralised db settings file. This can then be included in the site's settings.php code like this, so requiring the correct db settings for the environment.

```
if (file_exists('/var/www/vlad-db-settings.inc')) {
  require '/var/www/vlad-db-settings.inc';
}
```
