### PR TITLE
Load .bash_profile by full absolute path

### DIFF
--- a/vlad/playbooks/roles/ruby/tasks/ruby.yml
+++ b/vlad/playbooks/roles/ruby/tasks/ruby.yml
@@ -27,7 +27,7 @@
 
 # rbenv won't be available until we source ~/.bash_profile
 - name: source ~/.bash_profile
-  command: . ~/.bash_profile executable=/bin/bash
+  command: . /home/{{ user }}/.bash_profile executable=/bin/bash
 
 # debugging
 #- command: bash -lc "type rbenv"


### PR DESCRIPTION
When sourcing by relative path, I got this error

```
TASK: [ruby | source ~/.bash_profile] ***************************************** 
<127.0.0.1> REMOTE_MODULE command . ~/.bash_profile executable=/bin/bash
failed: [vlad] => {"changed": true, "cmd": [".", "~/.bash_profile"], "delta": "0:00:00.002385", "end": "2014-10-09 03:55:48.213379", "item": "", "rc": 127, "start": "2014-10-09 03:55:48.210994"}
stderr: .: ~/.bash_profile: No such file or directory
```

If I use full path, using variable `{{ user }}`, I don't have any problem.
