### PR TITLE
adjusting my.cnf location and values to ensure override settings

### DIFF
--- a/vlad/playbooks/roles/mysql/tasks/debian_mysql.yml
+++ b/vlad/playbooks/roles/mysql/tasks/debian_mysql.yml
@@ -2,7 +2,7 @@
 - name: install mysql packages
   apt: pkg={{ item }} state=installed
   sudo: true
-  with_items:    
+  with_items:
    - mysql-client
    - mysql-common
    - mysql-server
@@ -10,9 +10,9 @@
 
 # set up mysql variables
 - name: create MySQL configuration file
-  action: template src=debian_mysql.my.cnf.j2 dest=/etc/my.cnf
+  action: template src=debian_mysql.my.cnf.j2 dest=/etc/mysql/conf.d/my.cnf
   sudo: true
-  notify: 
+  notify:
   - restart mysql
 
 - name: change main settings for skip-external-locking
@@ -74,7 +74,7 @@
 
 - name: remove the MySQL test database
   mysql_db: db=test state=absent login_user=root login_password={{ mysql_root_password }}
-  
+
 # set up default database
 - name: create application database
   mysql_db: name={{ dbname }} state=present login_password={{ mysql_root_password }} login_user=root collation=utf8_general_ci

--- a/vlad/playbooks/roles/mysql/templates/debian_mysql.my.cnf.j2
+++ b/vlad/playbooks/roles/mysql/templates/debian_mysql.my.cnf.j2
@@ -1,6 +1,6 @@
 [mysqld]
 datadir=/var/lib/mysql
-socket=/var/lib/mysql/mysql.sock
+socket=/var/run/mysqld/mysqld.sock
 user=mysql
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0


### PR DESCRIPTION
I suggest the override my.cnf file is placed in /etc/mysql/conf.d/ as this is loaded after /etc/mysql/my.cnf

Additionally when i tested this the socket value was incorrect so have adjusted to:
```
socket=/var/run/mysqld/mysqld.sock
```