### PR TITLE
vm machine settings 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -150,8 +150,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       config.vm.box = "hashicorp/precise64"
 
       v.gui = false
-      v.vmx["numvcpus"] = "vagrant_cpus"
-      v.vmx["memsize"] = "vagrant_memory"
+      v.vmx["numvcpus"] = vagrant_cpus
+      v.vmx["memsize"] = vagrant_memory
     end
 
   else

--- a/vlad/playbooks/roles/base/tasks/aptget.yml
+++ b/vlad/playbooks/roles/base/tasks/aptget.yml
@@ -11,3 +11,4 @@
     - atop
     - vim
     - make
+    - iptables


### PR DESCRIPTION
Hi guys,

My vm's stopped firing up under vmware fusion provider and to be honest for a while I just cloned an old version locally that did work to get me by. Seems that it was because the vagrant file vm settings (cpu and memory) had quotes round plus there were no default values set for these variables. Have added this to example settings and fixed vagrant file bug.

I have also noticed some other oddities with vmware. iptables is not installed in the base box so added to the apt-get task which fixed that. Shall I add this as pull request?

Also Python mkdocs module errored as it seems to be there already, idempotency not working here! Will try and fix this too.

Rich