### PR TITLE
xdebug max nesting setting needs to be greater than default (100) for d8.

### DIFF
--- a/vlad/playbooks/roles/php/templates/php/php_apache2_xdebug.ini.j2
+++ b/vlad/playbooks/roles/php/templates/php/php_apache2_xdebug.ini.j2
@@ -9,3 +9,4 @@ xdebug.profiler_enable=0
 xdebug.profiler_output_dir=/tmp/xdebug_profiles
 xdebug.profiler_enable_trigger=1
 xdebug.profiler_output_name=cachegrind.out.%p
+xdebug.max_nesting_level=200


### PR DESCRIPTION
Running some testing today on d8 and appears the xdebug max nesting value should be higher by default.