### PR TITLE
Add Parallels support, fix provider config.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -149,26 +149,29 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vagrant_memory = settings_memory
   end
 
-  if vlad_os == "centos66"
-    # Add a Centos VirtualBox box
-    config.vm.box = "hansode/centos-6.6-x86_64"
-  elsif vlad_os == "ubuntu14"
-    # Add a Ubuntu VirtualBox box
-    config.vm.box = "ubuntu/trusty64"
-  else
-    # Add a Ubuntu VirtualBox box
-    config.vm.box = "ubuntu/precise64"
+  # VMWare provider settings
+  config.vm.provider "vmware_fusion" do |vmw, o|
+    # Add VMWare box.
+    o.vm.box = "hashicorp/precise64"
+
+    vmw.gui = false
+    vmw.vmx["numvcpus"] = vagrant_cpus
+    vmw.vmx["memsize"] = vagrant_memory
   end
 
-  # VMWare provider settings
-  config.vm.provider "vmware_fusion" do |vmw|
-    # Configure CPU number and amount of RAM memory.
-    vmw.vmx["memsize"] = vagrant_memory
-    vmw.vmx["numvcpus"] = vagrant_cpus
-  end
-  
   # Virtualbox provider settings
-  config.vm.provider "virtualbox" do |vb|
+  config.vm.provider "virtualbox" do |vb, o|
+    if vlad_os == "centos66"
+      # Add a Centos VirtualBox box
+      o.vm.box = "hansode/centos-6.6-x86_64"
+    elsif vlad_os == "ubuntu14"
+      # Add a Ubuntu VirtualBox box
+      o.vm.box = "ubuntu/trusty64"
+    else
+      # Add a Ubuntu VirtualBox box
+      o.vm.box = "ubuntu/precise64"
+    end
+
     #
     # Fixed settings
     #
@@ -185,8 +188,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     '--rtcuseutc', 'on',
     '--natdnshostresolver1', 'on',
     '--nictype1', 'virtio',
-    '--nictype2', 'virtio'] 
-    
+    '--nictype2', 'virtio']
+
     # Configure OS type
     if vlad_os == "centos66"
       vb.customize ["modifyvm", :id, "--ostype", "RedHat_64"]
@@ -203,6 +206,29 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--acpi", vconfig['vm_acpi']]
     vb.customize ["modifyvm", :id, "--ioapic", vconfig['vm_ioapic']]
     vb.customize ["modifyvm", :id, "--chipset", vconfig['vm_chipset']]
+  end
+
+  # Configure Parallels Desktop setup.
+  config.vm.provider "parallels" do |p, o|
+    if vlad_os == "centos66"
+      # Add a CentOS Parallels Desktop box
+      o.vm.box = "parallels/centos-6.6"
+    elsif vlad_os == "ubuntu14"
+      # Add an Ubuntu Parallels Desktop box
+      o.vm.box = "parallels/ubuntu-14.04"
+    else
+      # Add an Ubuntu Parallels Desktop box
+      o.vm.box = "parallels/ubuntu-12.04"
+    end
+
+    p.name = boxname + "_vlad"
+    p.cpus = vagrant_cpus
+    p.memory = vagrant_memory
+
+    # Update guest tools if so configured.
+    update_guest_tools = vconfig.has_key?('parallels_update_guest_tools') ? vconfig['parallels_update_guest_tools'] : false
+    p.update_guest_tools = update_guest_tools
+
   end
 
   if is_windows

--- a/vlad/example.settings.yml
+++ b/vlad/example.settings.yml
@@ -68,3 +68,110 @@
 
 # HTTP port for the Varnish cache
   varnish_http_port: 80
+
+# Administration email (used in instances when a server email is needed)
+  admin_mail: 'test@example.com'
+
+# PHP Settings
+# PHP Version, can be one of:
+# - "5.3"
+# - "5.4"
+# - "5.5"
+# - "5.6"
+# Note that Ubuntu14 won't install < PHP5.4 so you'll get PHP5.5+
+# Vlad will error when a version that isn't understood is used
+  php_version: "5.5"
+
+# php.ini settings
+  php_memory_limit: 512M
+  php_max_execution_time: 60
+  php_post_max_size: 100M
+  php_upload_max_filesize: 100M
+  php_display_errors: On
+  php_display_startup_errors: On
+  php_html_errors: On
+  php_date_timezone: Europe/London
+
+# Install PECL uploadprogress
+  php_pecl_uploadprogress: true
+
+# PHP APC Settings
+  apc_rfc1867: '1'
+  apc_shm_size: '256M'
+  apc_shm_segments: '1'
+  apc_num_files_hint: '0'
+
+# MySQL Settings
+  mysql_port: 3306
+  mysql_root_password: sdfds87643y5thgfd
+  server_hostname: vlad
+  dbname: vladdb
+  dbuser: vlad
+  dbpass: wibble
+
+# MySQL my.cnf settings
+  mysql_max_allowed_packet: 128M
+  innodb_buffer_pool_size: 128M
+  innodb_file_per_table: true
+  innodb_log_file_size: 128M
+  mysql_character_set_server: utf8
+  mysql_collation_server: utf8_general_ci
+  skip_name_resolve: true
+
+# SSH Settings
+  ssh_port: 22
+# Add RSA or DSA identity from host to guest on 'vagrant up'.
+# Does not support identites that require a passphrase. Options include:
+# false           : don't add anything
+# true           : add default files  (~/.ssh/id_rsa, ~/.ssh/id_dsa & ~/.ssh/identity)
+# "[filename]"  : add a specific file e.g. /Users/username/.ssh/[filename]
+  use_host_id: false
+
+# Varnish Settings
+  varnish_memory: 512
+
+# Drupal Solr integration
+# Select which Solr module to install
+# accepted values are 'search_api_solr' or 'apachesolr'
+  drupal_solr_package: "apachesolr"
+
+# Local hosts file location
+# Default location on *nix hosts is '/etc/hosts'
+# Default location for GasMask on OSX is '/Users/< username >/Library/Gas Mask/Local/< file >.hst'
+  hosts_file_location: "/etc/hosts"
+
+# Select whether Vlad should edit the hosts file.
+  hosts_file_update: true
+
+# Redis Port
+  redis_port: 6379
+
+# Set the level of verbosity that Ansible will use
+# This can be one of "", "v", "vv", "vvv", or "vvvv"
+  ansible_verbosity: ""
+
+# Import MySQL database from file on 'vagrant up'. Options include:
+# false          - don't import anything
+# true          - import from vlad_aux/db_io/vlad_up.sql.gz
+# "[filename]" - import from vlad_aux/db_io/[filename] (supports .sql, .bz2 and .gz files)
+  db_import_up: false
+
+# Add the default index.php file (useful to turn off if you are going git clone into the web root folder)
+  add_index_file: true
+
+# Git config user credentials (leave empty to skip this step)
+  git_user_name: ""
+  git_user_email: ""
+
+# Use 'nfs' or 'rsync' for VM file editing in synced folder
+  synced_folder_type: 'nfs'
+
+# The OS that vlad will use. This can be:
+# - "centos66"
+# - "ubuntu12"
+# - "ubuntu14"
+  vlad_os: "ubuntu14"
+
+# Whether to update the Parallels Desktop guest tools. Only relevant when using the parallels provider.
+# Adds a couple minutes to startup time whenever the tools are out of date.
+  parallels_update_guest_tools: true


### PR DESCRIPTION
Here's my shot at adding support for Parallels Desktop (specifically, the [`vagrant-parallels`](https://github.com/Parallels/vagrant-parallels) provider).

Three main things have happened here:

1. Reorganized the way Vlad handles provider-specific configuration. Instead of the not-always-most-optimal method of parsing command line arguments to figure out the provider, we simply use Vagrant's `override` parameter (abbreviated to `o`). This works the same (better, actually) than what Vlad was doing before. The problem this fixes is Vlad forgetting the proper box when using `vagrant reload` without `VAGRANT_DEFAULT_PROVIDER` set.
1. Added a provider-specific configuration block for `parallels`.
1. Added a setting (default `false`) for whether the Parallels Desktop guest tools should be updated or not. Since `vagrant-vbguest` handles this itself without configuration, and I have no idea what VMware does, I special-cased this to Parallels.

Tested for Parallels but should probably have the tires re-kicked with VirtualBox/VMware as well.