### PR TITLE
Adding optional support for MailHog.

### DIFF
--- a/vlad/example.settings.yml
+++ b/vlad/example.settings.yml
@@ -31,6 +31,8 @@
 
   mailcatcher_install: false
 
+  mailhog_install: false
+
   memcached_install: false
 
   munin_install: false

--- a/vlad/playbooks/roles/geerlingguy.daemonize/.travis.yml
+++ b/vlad/playbooks/roles/geerlingguy.daemonize/.travis.yml
@@ -1,0 +1,32 @@
+---
+language: python
+python: "2.7"
+
+env:
+  - SITE=test.yml
+
+before_install:
+  - sudo apt-get update -qq
+
+install:
+  # Install Ansible.
+  - pip install ansible
+
+  # Add ansible.cfg to pick up roles path.
+  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+
+script:
+  # Check the role/playbook's syntax.
+  - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
+
+  # Run the role/playbook with ansible-playbook.
+  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
+
+  # Run the role/playbook again, checking to make sure it's idempotent.
+  - >
+    ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+
+  - which daemonize

--- a/vlad/playbooks/roles/geerlingguy.daemonize/README.md
+++ b/vlad/playbooks/roles/geerlingguy.daemonize/README.md
@@ -1,0 +1,43 @@
+# Ansible Role: Daemonize
+
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-daemonize.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-daemonize)
+
+Installs [Daemonize](http://software.clapper.org/daemonize/), a tool for running commands as a Unix daemon.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+    workspace: /root
+
+The location where code will be downloaded and compiled.
+
+    daemonize_version: 1.7.5
+
+The daemonize release version to install.
+
+    daemonize_install_path: "/usr"
+
+The path where the compiled daemonize binary will be installed.
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+    - hosts: servers
+      roles:
+        - { role: geerlingguy.daemonize }
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role was created in 2014 by [Jeff Geerling](http://jeffgeerling.com/), author of [Ansible for DevOps](http://ansiblefordevops.com/).

--- a/vlad/playbooks/roles/geerlingguy.daemonize/defaults/main.yml
+++ b/vlad/playbooks/roles/geerlingguy.daemonize/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+workspace: /root
+
+daemonize_version: 1.7.5
+daemonize_install_path: "/usr"

--- a/vlad/playbooks/roles/geerlingguy.daemonize/meta/main.yml
+++ b/vlad/playbooks/roles/geerlingguy.daemonize/meta/main.yml
@@ -1,0 +1,28 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: geerlingguy
+  description: "Daemonize for Unix-like operating systems"
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 1.4
+  platforms:
+  - name: EL
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all
+  - name: Debian
+    versions:
+    - all
+  - name: GenericUNIX
+    versions:
+    - all
+    - any
+  categories:
+    - development
+    - web
+    - system
+    - mail

--- a/vlad/playbooks/roles/geerlingguy.daemonize/tasks/main.yml
+++ b/vlad/playbooks/roles/geerlingguy.daemonize/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Download daemonize archive.
+  get_url:
+    url: "https://github.com/bmc/daemonize/archive/release-{{ daemonize_version }}.tar.gz"
+    dest: "{{ workspace }}/daemonize-{{ daemonize_version }}.tar.gz"
+
+- name: Expand daemonize archive.
+  command: >
+    tar -zxf {{ workspace }}/daemonize-{{ daemonize_version }}.tar.gz
+    chdir={{ workspace }}
+    creates={{ workspace }}/daemonize-release-{{ daemonize_version }}/INSTALL
+
+- name: Check if daemonize is installed.
+  command: which daemonize
+  changed_when: false
+  failed_when: false
+  register: daemonize_installed
+
+- name: Build daemonize.
+  command: >
+    {{ item }}
+    chdir={{ workspace }}/daemonize-release-{{ daemonize_version }}
+  when: daemonize_installed|failed
+  with_items:
+    - ./configure
+    - "make prefix={{ daemonize_install_path }}"
+    - "make prefix={{ daemonize_install_path }} install"
+  sudo: yes

--- a/vlad/playbooks/roles/geerlingguy.daemonize/tests/inventory
+++ b/vlad/playbooks/roles/geerlingguy.daemonize/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/vlad/playbooks/roles/geerlingguy.daemonize/tests/test.yml
+++ b/vlad/playbooks/roles/geerlingguy.daemonize/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-role-daemonize

--- a/vlad/playbooks/roles/geerlingguy.mailhog/.travis.yml
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/.travis.yml
@@ -1,0 +1,33 @@
+---
+language: python
+python: "2.7"
+
+env:
+  - SITE=test.yml
+
+before_install:
+  - sudo apt-get update -qq
+
+install:
+  # Install Ansible.
+  - pip install ansible
+
+  # Add ansible.cfg to pick up roles path.
+  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+
+script:
+  # Check the role/playbook's syntax.
+  - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
+
+  # Run the role/playbook with ansible-playbook.
+  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
+
+  # Run the role/playbook again, checking to make sure it's idempotent.
+  - >
+    ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+
+  # TODO - Check if mailhog is listening.
+  # TODO - Check if an email sent into mailhog is accessible via API.

--- a/vlad/playbooks/roles/geerlingguy.mailhog/README.md
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/README.md
@@ -1,0 +1,57 @@
+# Ansible Role: MailHog
+
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-mailhog.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-mailhog)
+
+Installs [MailHog](https://github.com/ian-kent/Go-MailHog), a Go-based SMTP server and web UI/API for displaying captured emails, on RedHat or Debian-based linux systems. Also installs sSMTP so you can easily redirect local email to the SMTP server.
+
+Also installs sSMTP so you can redirect system mail to MailHog's built-in SMTP server.
+
+If you're using PHP and would like to route all PHP email into MailHog, you will need to update the `sendmail_path` configuration option in php.ini, like so:
+
+    sendmail_path = "/usr/sbin/ssmtp -t"
+
+## Requirements
+
+None.
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+    mailhog_binary_url: https://github.com/ian-kent/Go-MailHog/releases/download/0.07/Go-MailHog_linux_amd64
+
+The MailHog binary that will be installed. You can find the latest version or a 32-bit version by visiting the Go-MailHog GitHub project releases page.
+
+    mailhog_install_dir: /opt/mailhog
+
+The directory into which the MailHog binary will be installed.
+
+    ssmtp_mailhub: localhost:1025
+    ssmtp_root: postmaster
+    ssmtp_authuser: ""
+    ssmtp_authpass: ""
+    ssmtp_from_line_override: "YES"
+
+sSMTP options. These should work with MailHog's default configuration.
+
+## Dependencies
+
+  - geerlingguy.daemonize
+
+## Example Playbook
+
+    - hosts: servers
+      roles:
+        - { role: geerlingguy.mailhog }
+
+## TODO
+
+  - Add more runtime config (through init script/env vars) for MailHog (e.g. port, host, etc.).
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role was created in 2014 by [Jeff Geerling](http://jeffgeerling.com/), author of [Ansible for DevOps](http://ansiblefordevops.com/).

--- a/vlad/playbooks/roles/geerlingguy.mailhog/defaults/main.yml
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+mailhog_binary_url: https://github.com/ian-kent/Go-MailHog/releases/download/0.07/Go-MailHog_linux_amd64
+mailhog_install_dir: /opt/mailhog
+
+ssmtp_mailhub: localhost:1025
+ssmtp_root: postmaster
+ssmtp_authuser: ""
+ssmtp_authpass: ""
+ssmtp_from_line_override: "YES"

--- a/vlad/playbooks/roles/geerlingguy.mailhog/files/mailhog
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/files/mailhog
@@ -1,0 +1,60 @@
+#! /bin/sh
+# /etc/init.d/mailhog
+#
+# MailHog init script.
+#
+# @author Jeff Geerling
+
+### BEGIN INIT INFO
+# Provides:          mailhog
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start MailHog at boot time.
+# Description:       Enable MailHog.
+### END INIT INFO
+
+PID=/var/run/mailhog.pid
+LOCK=/var/lock/mailhog.lock
+USER=nobody
+BIN=/opt/mailhog/mailhog
+
+# Carry out specific functions when asked to by the system
+case "$1" in
+  start)
+    echo "Starting mailhog."
+    daemonize -p $PID -l $LOCK -u $USER $BIN
+    ;;
+  stop)
+    if [ -f $PID ]; then
+      echo "Stopping mailhog.";
+      kill -TERM $(cat $PID);
+      rm -f $PID;
+    else
+      echo "MailHog is not running.";
+    fi
+    ;;
+  restart)
+    echo "Restarting mailhog."
+    if [ -f $PID ]; then
+      kill -TERM $(cat $PID);
+      rm -f $PID;
+    fi
+    daemonize -p $PID -l $LOCK -u $USER $BIN
+    ;;
+  status)
+    if [ -f $PID ]; then
+      echo "MailHog is running.";
+    else
+      echo "MailHog is not running.";
+      exit 3
+    fi
+    ;;
+  *)
+    echo "Usage: /etc/init.d/mailhog {start|stop|status|restart}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/vlad/playbooks/roles/geerlingguy.mailhog/meta/.galaxy_install_info
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Sun Mar 15 04:58:52 2015', version: 1.0.0}

--- a/vlad/playbooks/roles/geerlingguy.mailhog/meta/main.yml
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/meta/main.yml
@@ -1,0 +1,25 @@
+---
+dependencies:
+  - { role: geerlingguy.daemonize }
+
+galaxy_info:
+  author: geerlingguy
+  description: "MailHog for Linux"
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 1.4
+  platforms:
+  - name: EL
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all
+  - name: Debian
+    versions:
+    - all
+  categories:
+    - development
+    - web
+    - system
+    - mail

--- a/vlad/playbooks/roles/geerlingguy.mailhog/tasks/main.yml
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# Install and configure MailHog.
+- name: Ensure mailhog install directory exists.
+  file:
+    path: "{{ mailhog_install_dir }}"
+    owner: root
+    group: root
+    state: directory
+    mode: 0755
+
+- name: Download MailHog binary.
+  get_url:
+    url: "{{ mailhog_binary_url }}"
+    dest: "{{ mailhog_install_dir }}/mailhog"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Copy mailhog init script into place.
+  copy:
+    src: mailhog
+    dest: /etc/init.d/mailhog
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Ensure mailhog is enabled and will start on boot.
+  service: name=mailhog state=started enabled=yes
+
+# Install and configure sSMTP.
+- include: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+
+- name: Copy sSMTP configuration.
+  template:
+    src: ssmtp.conf.j2
+    dest: /etc/ssmtp/ssmtp.conf
+    owner: root
+    group: root
+    mode: 0644
+
+# - name: Check if Gogs is running.
+#   command: service gogs status
+#   changed_when: false
+#   register: gogs_status
+
+# - name: Ensure Gogs is running.
+#   shell: >
+#     su -c "service gogs start" -s /bin/bash {{ gogs_user }}
+#   when: "'running' not in gogs_status.stdout"

--- a/vlad/playbooks/roles/geerlingguy.mailhog/tasks/setup-Debian.yml
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/tasks/setup-Debian.yml
@@ -1,0 +1,3 @@
+---
+- name: Install sSMTP.
+  apt: pkg=ssmtp state=installed

--- a/vlad/playbooks/roles/geerlingguy.mailhog/tasks/setup-RedHat.yml
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/tasks/setup-RedHat.yml
@@ -1,0 +1,3 @@
+---
+- name: Install sSMTP.
+  yum: pkg=ssmtp state=installed

--- a/vlad/playbooks/roles/geerlingguy.mailhog/templates/ssmtp.conf.j2
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/templates/ssmtp.conf.j2
@@ -1,0 +1,24 @@
+#
+# Config file for sSMTP sendmail
+#
+# The person who gets all mail for userids < 1000
+# Make this empty to disable rewriting.
+root={{ ssmtp_root }}
+
+# The place where the mail goes. The actual machine name is required no
+# MX records are consulted. Commonly mailhosts are named mail.domain.com
+mailhub={{ ssmtp_mailhub }}
+AuthUser={{ ssmtp_authuser }}
+AuthPass={{ ssmtp_authpass }}
+# TODO: Add UseTLS, UseSTARTTLS?
+
+# Where will the mail seem to come from?
+#rewriteDomain=
+
+# The full hostname
+hostname={{ inventory_hostname }}
+
+# Are users allowed to set their own From: address?
+# YES - Allow the user to specify their own From: address
+# NO - Use the system generated From: address
+FromLineOverride={{ ssmtp_from_line_override }}

--- a/vlad/playbooks/roles/geerlingguy.mailhog/tests/inventory
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/vlad/playbooks/roles/geerlingguy.mailhog/tests/test.yml
+++ b/vlad/playbooks/roles/geerlingguy.mailhog/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-role-mailhog

--- a/vlad/playbooks/site.yml
+++ b/vlad/playbooks/site.yml
@@ -91,6 +91,8 @@
 
     - { role: mailcatcher, tags: ["mailcatcher"], when: "mailcatcher_install" }
 
+    - { role: geerlingguy.mailhog, tags: ["mailhog"], when: "mailhog_install", sudo: true, workspace: /home/vagrant }
+
     - { role: node, tags: ["node"], when: "node_install" }
 
     - { role: imagemagick, tags: ["imagemagick"], when: "imagemagick_install" }


### PR DESCRIPTION
As discussed in issue #173 , this pull request adds optional support for MailHog.

Once the guest operating system has been provisioned, you should be able to access the MailHog web interface using port 8025. For example, if `webserver_hostname` is set to `drupal.local`, then MailHog should be available on http://drupal.local:8025. Additional information is available in [MailHog's README.md file](https://github.com/mailhog/MailHog/blob/master/README.md).

The idea is ultimately to replace MailCatcher, though I haven't yet stripped it out in this pull request. I figured it would make sense for someone with more experience using MailCatcher to test and verify that MailHog is a suitable replacement first.

Ultimately, adding the contents from the geerlingguy.daemonize and geerlingguy.mailhog roles into VLAD without a connection to their respective repositories may not be the best way to do it, but it seemed like a quick option for testing and possibly the easiest in terms of fitting in with the way VLAD already works. I didn't want to hassle with trying to get git submodules to work or add that complexity to VLAD. I was also able to get Ansible Galaxy to work, but I had to add a requirements.txt file to get that to work, plus that still seemed to require using the ansible-galaxy command the first time you wanted to install MailHog. I'm definitely open to suggestions, but I was trying to error on the side of keeping things simple for the end user.