### PR TITLE
#186 Enter apache2_docroot, aware of OS family and distribution.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,6 +71,7 @@ boxname = vconfig['boxname']
 boxwebaddress = vconfig['webserver_hostname']
 hostname_aliases = vconfig['webserver_hostname_aliases']
 synced_folder_type = vconfig['synced_folder_type']
+apache2_docroot = vconfig['apache2_docroot']
 vlad_os = vconfig['vlad_os']
 
 # Detect the current provider and set a variable.
@@ -208,7 +209,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Setup auxiliary synced folder
 
     FileUtils.mkdir_p vconfig['aux_synced_folder'] if !File.exist?(vconfig['aux_synced_folder'])
-    config.vm.synced_folder vconfig['aux_synced_folder'], "/var/www/site/vlad_aux", 
+    config.vm.synced_folder vconfig['aux_synced_folder'], apache2_docroot + "/vlad_aux", 
       type: "smb", 
       id: "vagrant-aux", 
       smb_username: samba_username, 
@@ -220,18 +221,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
 
     # Setup synced folder for site files
-    config.vm.synced_folder vconfig['host_synced_folder'], "/var/www/site/docroot", type: "nfs", create: true, id: "vagrant-webroot"
+    config.vm.synced_folder vconfig['host_synced_folder'], apache2_docroot + "/drupal", type: "nfs", create: true, id: "vagrant-webroot"
 
     # Setup auxiliary synced folder
-    config.vm.synced_folder vconfig['aux_synced_folder'], "/var/www/site/vlad_aux", type: "nfs", create: true, id: "vagrant-aux"
+    config.vm.synced_folder vconfig['aux_synced_folder'], apache2_docroot + "/vlad_aux", type: "nfs", create: true, id: "vagrant-aux"
 
   elsif synced_folder_type == 'rsync'
 
     # Setup synced folder for site files
-    config.vm.synced_folder vconfig['host_synced_folder'], "/var/www/site/docroot", type: "rsync", create: true, id: "vagrant-webroot"
+    config.vm.synced_folder vconfig['host_synced_folder'], apache2_docroot + "/drupal", type: "rsync", create: true, id: "vagrant-webroot"
 
     # Setup auxiliary synced folder
-    config.vm.synced_folder vconfig['aux_synced_folder'], "/var/www/site/vlad_aux", type: "rsync", create: true, id: "vagrant-aux"
+    config.vm.synced_folder vconfig['aux_synced_folder'], apache2_docroot + "/vlad_aux", type: "rsync", create: true, id: "vagrant-aux"
 
   else
 

--- a/vlad/example.settings.yml
+++ b/vlad/example.settings.yml
@@ -23,9 +23,7 @@
 # Vagrantfile configuration
   boxipaddress: "192.168.100.100"
   boxname: "vlad"
-  host_synced_folder: "./docroot"
-# or on Windows
-#  host_synced_folder: "C:\\docroot"
+  host_synced_folder: "./drupal"
 
 # Install components:
 # - To install a component set it to true.
@@ -68,3 +66,8 @@
 
 # HTTP port for the Varnish cache
   varnish_http_port: 80
+
+# Apache 2 document root. For ubuntu12:
+#  apache2_docroot: "/var/www"
+# For ubuntu14 and centos66:
+  apache2_docroot: "/var/www/html"

--- a/vlad/playbooks/local_halt_destroy.yml
+++ b/vlad/playbooks/local_halt_destroy.yml
@@ -18,7 +18,7 @@
     sudo: true
 
   - name: local actions destroy | dump vlad database
-    mysql_db: name={{ dbname }} state=dump target=/var/www/site/vlad_aux/db_io/vlad_destroy.sql.gz login_password={{ mysql_root_password }} login_user=root
+    mysql_db: name={{ dbname }} state=dump target={{ apache2_docroot }}/vlad_aux/db_io/vlad_destroy.sql.gz login_password={{ mysql_root_password }} login_user=root
     when: mysql_install
     ignore_errors: yes
     sudo: true

--- a/vlad/playbooks/roles/adminer/tasks/adminer.yml
+++ b/vlad/playbooks/roles/adminer/tasks/adminer.yml
@@ -1,22 +1,22 @@
 ---
 - name: create adminer directory
-  file: path=/var/www/adminer state=directory
+  file: path={{ apache2_docroot }}/adminer state=directory
   sudo: true
 
 - name: copy adminer
-  copy: src=adminer-4.2.1.php dest=/var/www/adminer/adminer-4.2.1.php
+  copy: src=adminer-4.2.1.php dest={{ apache2_docroot }}/adminer/adminer-4.2.1.php
   sudo: true
 
 - name: copy adminer stylesheet
-  copy: src=adminer.css dest=/var/www/adminer/adminer.css
+  copy: src=adminer.css dest={{ apache2_docroot }}/adminer/adminer.css
   sudo: true
 
 - name: copy index.php configuration file into place
-  template: src=index.j2 dest=/var/www/adminer/index.php
+  template: src=index.j2 dest={{ apache2_docroot }}/adminer/index.php
   sudo: true
 
 - name: ensure adminer directory permissions
-  file: path=/var/www/adminer mode=0777 recurse=yes
+  file: path={{ apache2_docroot }}/adminer mode=0777 recurse=yes
   sudo: true
 
 - name: add vhost for adminer (Debian)

--- a/vlad/playbooks/roles/adminer/templates/apache_adminer_vhost.j2
+++ b/vlad/playbooks/roles/adminer/templates/apache_adminer_vhost.j2
@@ -2,9 +2,9 @@
   ServerAdmin {{ admin_mail }}
   ServerName adminer.{{ webserver_hostname }}
 
-  DocumentRoot /var/www/adminer
+  DocumentRoot {{ apache2_docroot }}/adminer
 
-  <Directory "/var/www/adminer/">
+  <Directory "{{ apache2_docroot }}/adminer/">
     Options FollowSymLinks MultiViews
     AllowOverride All
     Order allow,deny
@@ -19,8 +19,8 @@
     {% endif %}
   </Directory>
 
-  ErrorLog /var/www/site/logs/adminer.error.log
+  ErrorLog {{ apache2_docroot }}/logs/adminer.error.log
 
   LogLevel warn
-  CustomLog /var/www/site/logs/adminer.access.log combined
+  CustomLog {{ apache2_docroot }}/logs/adminer.access.log combined
 </VirtualHost>

--- a/vlad/playbooks/roles/apache/tasks/main.yml
+++ b/vlad/playbooks/roles/apache/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: set up directories (with logs directory)
-  file: path=/var/www/site/logs state=directory recurse=yes
+  file: path={{ apache2_docroot }}/logs state=directory recurse=yes
   sudo: true
 
 # Include the appropriate OS specific setups.
@@ -18,12 +18,12 @@
 
 # Run some common tasks.
 - name: symlink www directory from home directory
-  file: src=/var/www/site/docroot dest=/home/{{ user }}/www state=link
+  file: src={{ apache2_docroot }} dest=/home/{{ user }}/www state=link
 
-- name: set default login directory to be /var/www/site/docroot
-  lineinfile: dest=/home/{{ user }}/.bashrc state=present line='cd /var/www/site/docroot'
+- name: set default login directory to be {{ apache2_docroot }}
+  lineinfile: dest=/home/{{ user }}/.bashrc state=present line='cd {{ apache2_docroot }}'
   tags: apache2
 
-- name: add www-data user to dialout group
-  user: name=www-data groups=dialout append=yes
+- name: add apache2_user to dialout group
+  user: name={{ apache2_user }} groups=dialout append=yes
   sudo: true

--- a/vlad/playbooks/roles/apache/templates/apache_vhost.j2
+++ b/vlad/playbooks/roles/apache/templates/apache_vhost.j2
@@ -6,17 +6,17 @@
 {% endfor %}
   ServerAlias *.vagrantshare.com
 
-  DocumentRoot /var/www/site/docroot
+  DocumentRoot  {{ apache2_docroot }}/drupal
 
-  <Directory /var/www/site/docroot>
+  <Directory {{ apache2_docroot }}/drupal>
     Options FollowSymLinks MultiViews
     AllowOverride All
     Order allow,deny
     allow from all
   </Directory>
 
-  ErrorLog /var/www/site/logs/error.log
+  ErrorLog {{ apache2_docroot }}/logs/error.log
 
   LogLevel warn
-  CustomLog /var/www/site/logs/access.log combined
+  CustomLog {{ apache2_docroot }}/logs/access.log combined
 </VirtualHost>

--- a/vlad/playbooks/roles/apache/templates/debian_apache_ssl_vhost.j2
+++ b/vlad/playbooks/roles/apache/templates/debian_apache_ssl_vhost.j2
@@ -7,22 +7,22 @@
       {% endfor %}
         ServerAlias *.vagrantshare.com
 
-        DocumentRoot /var/www/site/docroot
+        DocumentRoot {{ apache2_docroot }}/drupal
 
-        <Directory /var/www/site/docroot>
+        <Directory {{ apache2_docroot }}/drupal>
                 Options Indexes FollowSymLinks MultiViews
                 AllowOverride All
                 Order allow,deny
                 allow from all
         </Directory>
 
-        ErrorLog /var/www/site/logs/ssl_error.log
+        ErrorLog {{ apache2_docroot }}/logs/ssl_error.log
 
         # Possible values include: debug, info, notice, warn, error, crit,
         # alert, emerg.
         LogLevel warn
 
-        CustomLog /var/www/site/logs/ssl_access.log combined
+        CustomLog {{ apache2_docroot }}/logs/ssl_access.log combined
 
         #   SSL Engine Switch:
         #   Enable/Disable SSL for this virtual host.

--- a/vlad/playbooks/roles/apache/templates/redhat_apache_ssl_vhost.j2
+++ b/vlad/playbooks/roles/apache/templates/redhat_apache_ssl_vhost.j2
@@ -80,22 +80,22 @@ SSLCryptoDevice builtin
   {% endfor %}
     ServerAlias *.vagrantshare.com
 
-    DocumentRoot /var/www/site/docroot
+    DocumentRoot {{ apache2_docroot }}/docroot
 
-    <Directory /var/www/site/docroot>
+    <Directory {{ apache2_docroot }}/docroot>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride All
         Order allow,deny
         allow from all
     </Directory>
 
-    ErrorLog /var/www/site/logs/ssl_error.log
+    ErrorLog {{ apache2_docroot }}/logs/ssl_error.log
 
     # Possible values include: debug, info, notice, warn, error, crit,
     # alert, emerg.
     LogLevel warn
 
-    CustomLog /var/www/site/logs/ssl_access.log combined
+    CustomLog {{ apache2_docroot }}/logs/ssl_access.log combined
 
     #   SSL Engine Switch:
     #   Enable/Disable SSL for this virtual host.
@@ -194,7 +194,7 @@ SSLCryptoDevice builtin
     <Files ~ "\.(cgi|shtml|phtml|php3?)$">
         SSLOptions +StdEnvVars
     </Files>
-    <Directory "/var/www/cgi-bin">
+    <Directory "{{ apache2_docroot }}/cgi-bin">
         SSLOptions +StdEnvVars
     </Directory>
 

--- a/vlad/playbooks/roles/base/tasks/main.yml
+++ b/vlad/playbooks/roles/base/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: ensure certain vlad_aux subdirectories exist
-  file: path=/var/www/site/vlad_aux/{{ item }} state=directory
+  file: path={{ apache2_docroot }}/vlad_aux/{{ item }} state=directory
   with_items:
     - tmp
     - db_io

--- a/vlad/playbooks/roles/base/tasks/vm_info.yml
+++ b/vlad/playbooks/roles/base/tasks/vm_info.yml
@@ -4,7 +4,7 @@
 # TODO: If the above TODO is completed, ensure that any redundant copied settings files are removed from vlad_aux/tmp/
 
 - name: vm info | create current_build_settings.yml at vlad_ux/tmp/
-  copy: src={{ item }} dest=/var/www/site/vlad_aux/tmp/current_build_settings.yml
+  copy: src={{ item }} dest={{ apache2_docroot }}/vlad_aux/tmp/current_build_settings.yml
   with_first_found:
     - ../../../../../../settings/vlad_settings.yml
     - ../../../../../settings/vlad_settings.yml
@@ -12,7 +12,7 @@
     - ../../../vars/dummy_settings.yml
 
 - name: vm info | create current_local_overrides.yml at vlad_ux/tmp/
-  copy: src={{ item }} dest=/var/www/site/vlad_aux/tmp/current_local_overrides.yml
+  copy: src={{ item }} dest={{ apache2_docroot }}/vlad_aux/tmp/current_local_overrides.yml
   with_first_found:
     - ../../../../../../settings/vlad_local_settings.yml
     - ../../../../../settings/vlad_local_settings.yml

--- a/vlad/playbooks/roles/drupal/tasks/drupal_install.yml
+++ b/vlad/playbooks/roles/drupal/tasks/drupal_install.yml
@@ -2,8 +2,8 @@
 
 - name: drupal install | copy Drupal installation scripts
   template:
-    src: drupal{{ item }}_install.j2
-    dest: /var/www/drupal{{ item }}_install.sh
+    src="drupal{{ item }}_install.j2"
+    dest="{{ apache2_docroot }}/drupal{{ item }}_install.sh"
   with_items:
     - 6
     - 7
@@ -13,10 +13,20 @@
 
 # Setting "mode" to 755 in the above template task appears to have no effect :(
 - name: drupal install | set Drupal installation scripts to executable
-  file: path=/var/www/drupal{{ item }}_install.sh mode=755
+  file: 
+    path="{{ apache2_docroot }}/drupal{{ item }}_install.sh" 
+    mode=755
   with_items:
     - 6
     - 7
     - 8
     - 8dev
   sudo: true
+
+- name: drupal install | create drupal folder
+  file:
+    path={{ apache2_docroot }}/drupal
+    state=directory
+    owner={{ user }}
+    group={{ user }}
+    recurse=yes

--- a/vlad/playbooks/roles/drupal/tasks/drush.yml
+++ b/vlad/playbooks/roles/drupal/tasks/drush.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ensure certain vlad_aux subdirectories exist
-  file: path=/var/www/site/vlad_aux/{{ item }} state=directory
+  file: path={{ apache2_docroot }}/vlad_aux/{{ item }} state=directory
   with_items:
     - drush_backups
     - drush_dumps

--- a/vlad/playbooks/roles/drupal/tasks/drush_make.yml
+++ b/vlad/playbooks/roles/drupal/tasks/drush_make.yml
@@ -1,34 +1,34 @@
 ---
 
 # Testing if docroot is empty will be determined by the presence of the "modules" subdirectory (used by Drupal 6, 7 & 8).
-- name: drush_make | Get stats on docroot/modules directory
-  stat: path=/var/www/site/docroot/modules
+- name: drush_make | Get stats on drupal/modules directory
+  stat: path={{ apache2_docroot }}/drupal/modules
   register: stat_docroot_modules_dir
 
-- name: drush_make | Get stats on docroot/index.php
-  stat: path=/var/www/site/docroot/index.php
+- name: drush_make | Get stats on drupal/index.php
+  stat: path={{ apache2_docroot }}/drupal/index.php
   register: stat_docroot_index_page
 
 - name: drush_make | Check if docroot/index.php is Vlad's holding page
-  shell: grep "Vlad holding page (index.php)" /var/www/site/docroot/index.php
+  shell: grep "Vlad holding page (index.php)" {{ apache2_docroot }}/drupal/index.php
   register: vlad_holding_page_present
   when: stat_docroot_index_page.stat.exists
   ignore_errors: yes
 
 - name: drush_make | Remove Vlad's holding page if present (index.php)
-  file: path=/var/www/site/docroot/index.php state=absent
+  file: path={{ apache2_docroot }}/drupal/index.php state=absent
   when: vlad_holding_page_present.stdout != ""
 
 # Run drush make only if docroot is empty.
 - name: drush_make | Run drush make
-  command: drush make {{ drush_make_options }} /var/www/site/vlad_aux/make/{{ drush_make_file }} -y
+  command: drush make {{ drush_make_options }} {{ apache2_docroot }}/vlad_aux/make/{{ drush_make_file }} -y
   args:
-    chdir: /var/www/site/docroot
+    chdir= {{ apache2_docroot }}/drupal
   when: stat_docroot_modules_dir.stat.exists != true
 
 # Run drush make every time the VM is provisioned if docroot is not empty.
 - name: drush_make | Run drush make (force)
-  command: drush make {{ drush_make_options }} /var/www/site/vlad_aux/make/{{ drush_make_file }} -y
+  command: drush make {{ drush_make_options }} {{ apache2_docroot }}/vlad_aux/make/{{ drush_make_file }} -y
   args:
-    chdir: /var/www/site/docroot
+    chdir= {{ apache2_docroot }}/drupal
   when: stat_docroot_modules_dir.stat.exists and drush_make_force == true

--- a/vlad/playbooks/roles/drupal/tasks/main.yml
+++ b/vlad/playbooks/roles/drupal/tasks/main.yml
@@ -3,12 +3,12 @@
 - include: drush.yml
   tags: drush
 
-- include: drush_aliases.yml
-  tags: drush_aliases
+#- include: drush_aliases.yml
+#  tags: drush_aliases
 
-- include: drush_make.yml
-  when: drush_make_file != ""
-  tags: drush_make
+#- include: drush_make.yml
+#  when: drush_make_file != ""
+#  tags: drush_make
 
 - include: drupal_install.yml
   tags: drupal_install

--- a/vlad/playbooks/roles/drupal/templates/drupal6_install.j2
+++ b/vlad/playbooks/roles/drupal/templates/drupal6_install.j2
@@ -1,11 +1,11 @@
 # Move into the site directory.
-cd /var/www/site/
+cd {{ apache2_docroot }}/
 
 # Download the latest recommended release of Drupal 6.x into docroot.
-drush dl drupal-6 --drupal-project-rename=docroot --yes
+drush dl drupal-6 --drupal-project-rename=drupal --yes
 
 # Move into the docroot directory.
-cd docroot
+cd drupal
 
 # Create some directories.
 mkdir sites/default/files

--- a/vlad/playbooks/roles/drupal/templates/drupal7_install.j2
+++ b/vlad/playbooks/roles/drupal/templates/drupal7_install.j2
@@ -1,11 +1,11 @@
 # Move into the site directory.
-cd /var/www/site/
+cd {{ apache2_docroot }}/
 
 # Download the latest recommended release of Drupal 7.x into docroot.
-drush dl drupal-7 --drupal-project-rename=docroot --yes
+drush dl drupal-7 --drupal-project-rename=drupal --yes
 
 # Move into the docroot directory.
-cd docroot
+cd drupal
 
 # Create some directories.
 mkdir sites/default/files

--- a/vlad/playbooks/roles/drupal/templates/drupal8_install.j2
+++ b/vlad/playbooks/roles/drupal/templates/drupal8_install.j2
@@ -1,19 +1,19 @@
 # Remove everything that might be in the docroot directory.
-rm -rf /var/www/site/docroot/.* /var/www/site/docroot/*
+rm -rf {{ apache2_docroot }}/drupal/.* {{ apache2_docroot }}/drupal/*
 
 # Clone latest Drupal 8 beta release into the docroot direcory.
-git ls-remote --tags http://git.drupal.org/project/drupal.git | grep refs/tags/8\.0\.0-beta | xargs -n1 | tail -n 1 |  sed 's/refs\/tags\///' | xargs -I % git clone --branch % http://git.drupal.org/project/drupal.git /var/www/site/docroot
+git ls-remote --tags http://git.drupal.org/project/drupal.git | grep refs/tags/8\.0\.0-beta | xargs -n1 | tail -n 1 |  sed 's/refs\/tags\///' | xargs -I % git clone --branch % http://git.drupal.org/project/drupal.git {{ apache2_docroot }}/drupal
 
 # Create a settings.php fie.
-cp /var/www/site/docroot/sites/default/default.settings.php /var/www/site/docroot/sites/default/settings.php
+cp {{ apache2_docroot }}/drupal/sites/default/default.settings.php {{ apache2_docroot }}/drupal/sites/default/settings.php
 
 # Create some directories.
-mkdir /var/www/site/docroot/modules/contrib
-mkdir /var/www/site/docroot/modules/custom
+mkdir {{ apache2_docroot }}/drupal/modules/contrib
+mkdir {{ apache2_docroot }}/drupal/modules/custom
 
 # Set some lenient permissions on the docroot directory.
-chmod -R 777 /var/www/site/docroot
+chmod -R 777 {{ apache2_docroot }}/drupal
 
 # Install Drupal using the drush-master.
-cd /var/www/site/docroot
+cd {{ apache2_docroot }}/drupal
 /home/vagrant/drush-master/drush site-install --db-url=mysql://{{ dbuser }}:{{ dbpass }}@localhost/{{ dbname[0] }} --account-name=admin --account-pass=password --yes

--- a/vlad/playbooks/roles/drupal/templates/drupal8dev_install.j2
+++ b/vlad/playbooks/roles/drupal/templates/drupal8dev_install.j2
@@ -1,19 +1,19 @@
 # Remove everything that might be in the docroot directory.
-rm -rf /var/www/site/docroot/.* /var/www/site/docroot/*
+rm -rf {{ apache2_docroot }}/drupal/.* {{ apache2_docroot }}/drupal/*
 
 # Clone Drupal 8 dev branch into the docroot direcory.
-git clone --branch 8.0.x http://git.drupal.org/project/drupal.git /var/www/site/docroot
+git clone --branch 8.0.x http://git.drupal.org/project/drupal.git {{ apache2_docroot }}/drupal
 
 # Create a settings.php fie.
-cp /var/www/site/docroot/sites/default/default.settings.php /var/www/site/docroot/sites/default/settings.php
+cp {{ apache2_docroot }}/drupal/sites/default/default.settings.php {{ apache2_docroot }}/drupal/sites/default/settings.php
 
 # Create some directories.
-mkdir /var/www/site/docroot/modules/contrib
-mkdir /var/www/site/docroot/modules/custom
+mkdir {{ apache2_docroot }}/drupal/modules/contrib
+mkdir {{ apache2_docroot }}/drupal/modules/custom
 
 # Set some lenient permissions on the docroot directory.
-chmod -R 777 /var/www/site/docroot
+chmod -R 777 {{ apache2_docroot }}/drupal
 
 # Install Drupal using the drush-master.
-cd /var/www/site/docroot
+cd {{ apache2_docroot }}/drupal
 /home/vagrant/drush-master/drush site-install --db-url=mysql://{{ dbuser }}:{{ dbpass }}@localhost/{{ dbname[0] }} --account-name=admin --account-pass=password --yes

--- a/vlad/playbooks/roles/drupal/templates/drushrc.php.j2
+++ b/vlad/playbooks/roles/drupal/templates/drushrc.php.j2
@@ -1,10 +1,10 @@
 <?php
 
 // Set default destination for drush backups
-$options['backup-dir'] = '/var/www/site/vlad_aux/drush_backups';
+$options['backup-dir'] = '{{ apache2_docroot }}/vlad_aux/drush_backups';
 
 // Set default destination for drush sql dumps
-$options['dump-dir'] = '/var/www/site/vlad_aux/db_io/drush_dumps';
+$options['dump-dir'] = '{{ apache2_docroot }}/vlad_aux/db_io/drush_dumps';
 
 // Set additional location for drush alias files
 $options['alias-path'] = '/home/{{ user }}/.drush/aliases/separate';

--- a/vlad/playbooks/roles/mysql/tasks/debian_mysql.yml
+++ b/vlad/playbooks/roles/mysql/tasks/debian_mysql.yml
@@ -99,7 +99,7 @@
   changed_when: false
 
 - name: import database (default source file)
-  mysql_db: name={{ item[0] }} state=import target=/var/www/site/vlad_aux/db_io/vlad_up.sql.gz login_password={{ mysql_root_password }} login_user=root
+  mysql_db: name={{ item[0] }} state=import target={{ apache2_docroot }}/vlad_aux/db_io/vlad_up.sql.gz login_password={{ mysql_root_password }} login_user=root
   when: db_import_up and mysql_tables.stdout == ""
   ignore_errors: yes
   tags: mysql_import
@@ -107,7 +107,7 @@
     - dbname
 
 - name: import database (specified source file)
-  mysql_db: name={{ item[0] }} state=import target=/var/www/site/vlad_aux/db_io/{{ db_import_up }} login_password={{ mysql_root_password }} login_user=root
+  mysql_db: name={{ item[0] }} state=import target={{ apache2_docroot }}/vlad_aux/db_io/{{ db_import_up }} login_password={{ mysql_root_password }} login_user=root
   when: db_import_up != true and db_import_up != false and mysql_tables.stdout == ""
   ignore_errors: yes
   tags: mysql_import

--- a/vlad/playbooks/roles/mysql/tasks/main.yml
+++ b/vlad/playbooks/roles/mysql/tasks/main.yml
@@ -3,8 +3,8 @@
   local_action: setup filter=ansible_default_ipv4
   register: local_ipv4_address
 
-- name: ensure directory /var/www/site/vlad_aux/db_io exists
-  file: path=/var/www/site/vlad_aux/db_io state=directory
+- name: ensure directory {{ apache2_docroot }}/vlad_aux/db_io exists
+  file: path={{ apache2_docroot }}/vlad_aux/db_io state=directory
 
 - include: debian_mysql.yml
   when: ansible_os_family == "Debian"

--- a/vlad/playbooks/roles/mysql/tasks/redhat_mysql.yml
+++ b/vlad/playbooks/roles/mysql/tasks/redhat_mysql.yml
@@ -94,7 +94,7 @@
   changed_when: false
 
 - name: import database (default source file)
-  mysql_db: name={{ item[0] }} state=import target=/var/www/site/vlad_aux/db_io/vlad_up.sql.gz login_password={{ mysql_root_password }} login_user=root
+  mysql_db: name={{ item[0] }} state=import target={{ apache2_docroot }}/vlad_aux/db_io/vlad_up.sql.gz login_password={{ mysql_root_password }} login_user=root
   when: db_import_up and mysql_tables.stdout == ""
   ignore_errors: yes
   tags: mysql_import
@@ -102,7 +102,7 @@
     - dbname
 
 - name: import database (specified source file)
-  mysql_db: name={{ item[0] }} state=import target=/var/www/site/vlad_aux/db_io/{{ db_import_up }} login_password={{ mysql_root_password }} login_user=root
+  mysql_db: name={{ item[0] }} state=import target={{ apache2_docroot }}/vlad_aux/db_io/{{ db_import_up }} login_password={{ mysql_root_password }} login_user=root
   when: db_import_up != true and db_import_up != false and mysql_tables.stdout == ""
   ignore_errors: yes
   tags: mysql_import

--- a/vlad/playbooks/roles/pimpmylog/tasks/pimpmylog.yml
+++ b/vlad/playbooks/roles/pimpmylog/tasks/pimpmylog.yml
@@ -1,13 +1,13 @@
 ---
 - name: get pimpmylog package
   git:
-    repo: https://github.com/potsky/PimpMyLog.git
-    dest: /var/www/pimpmylog
-    depth: 1
+    repo= https://github.com/potsky/PimpMyLog.git
+    dest= {{ apache2_docroot }}/pimpmylog
+    depth= 1
   sudo: true
 
 - name: ensure that the package isn't effected by mode changes
-  command: git config core.filemode false chdir=/var/www/pimpmylog
+  command: git config core.filemode false chdir={{ apache2_docroot }}/pimpmylog
   sudo: true
   changed_when: false
 
@@ -33,11 +33,11 @@
     - restart httpd
 
 - name: ensure Pimpmylog directory permissions
-  file: path=/var/www/pimpmylog mode=0777 recurse=yes state=directory
+  file: path={{ apache2_docroot }}/pimpmylog mode=0777 recurse=yes state=directory
   sudo: true
   changed_when: false
 
 - name: add configuration file
-  copy: src=config.user.json dest=/var/www/pimpmylog/config.user.json
+  copy: src=config.user.json dest={{ apache2_docroot }}/pimpmylog/config.user.json
   sudo: true
 

--- a/vlad/playbooks/roles/pimpmylog/templates/apache_pimpmylog_vhost.j2
+++ b/vlad/playbooks/roles/pimpmylog/templates/apache_pimpmylog_vhost.j2
@@ -2,9 +2,9 @@
   ServerAdmin {{ admin_mail }}
   ServerName logs.{{ webserver_hostname }}
 
-  DocumentRoot /var/www/pimpmylog/
+  DocumentRoot {{ apache2_docroot }}/pimpmylog/
 
-  <Directory "/var/www/pimpmylog/">
+  <Directory "{{ apache2_docroot }}/pimpmylog/">
     Options FollowSymLinks MultiViews
     AllowOverride All
     Order allow,deny
@@ -19,9 +19,9 @@
     {% endif %}
   </Directory>
 
-  ErrorLog /var/www/site/logs/logs.error.log
+  ErrorLog {{ apache2_docroot }}/logs/logs.error.log
 
   LogLevel warn
-  CustomLog /var/www/site/logs/logs.access.log combined
+  CustomLog {{ apache2_docroot }}/logs/logs.access.log combined
 
 </VirtualHost>

--- a/vlad/playbooks/roles/samba/templates/smb-vlad.conf
+++ b/vlad/playbooks/roles/samba/templates/smb-vlad.conf
@@ -1,12 +1,12 @@
 [docroot]
-    comment = Local Dev Server - /var/www/site
-    path = /var/www/site
+    comment = Local Dev Server - {{ apache2_docroot }}
+    path = {{ apache2_docroot }}
     browsable = yes
     guest ok = yes
     read only = no
     create mask = 0664
     force user = vagrant
-    force group = www-data
+    force group = {{ apache2_group }}
 #[docroot] End
 
 [vagrant]

--- a/vlad/playbooks/roles/xhprof/tasks/debian_xhprof.yml
+++ b/vlad/playbooks/roles/xhprof/tasks/debian_xhprof.yml
@@ -52,10 +52,10 @@
 
 - name: get xhprof_html package
   git:
-    repo: https://github.com/preinheimer/xhprof
-    dest: /var/www/xhprof_html
-    update: no
-    depth: 1
+    repo= https://github.com/preinheimer/xhprof
+    dest= {{ apache2_docroot }}/xhprof_html
+    update= no
+    depth= 1
   sudo: true
 
 - name: create xhprof_html application database
@@ -68,20 +68,20 @@
    - 127.0.0.1
    - localhost
 
-- name: ensure directory /var/www/xhprof_html/xhprof_lib exists
-  file: path=/var/www/xhprof_html/xhprof_lib state=directory
+- name: ensure directory {{ apache2_docroot }}/xhprof_html/xhprof_lib exists
+  file: path={{ apache2_docroot }}/xhprof_html/xhprof_lib state=directory
   sudo: true
 
 - name: copy SQL install script
-  copy: src=install.mysql dest=/var/www/xhprof_html/install.sql
+  copy: src=install.mysql dest={{ apache2_docroot }}/xhprof_html/install.sql
   sudo: true
 
 - name: copy configuration file
-  template: src=xhprof_config_php.j2 dest=/var/www/xhprof_html/xhprof_lib/config.php
+  template: src=xhprof_config_php.j2 dest={{ apache2_docroot }}/xhprof_html/xhprof_lib/config.php
   sudo: true
 
 - name: run SQL install script
-  shell: mysql --user={{ dbuser }} --password={{ dbpass }} xhprof < /var/www/xhprof_html/install.sql
+  shell: mysql --user={{ dbuser }} --password={{ dbpass }} xhprof < {{ apache2_docroot }}/xhprof_html/install.sql
   sudo: true
 
 - name: check virtual host for xhprof include
@@ -94,7 +94,7 @@
 - name: add virtual server item if include not found
   lineinfile: dest=/etc/apache2/sites-enabled/{{ webserver_hostname }}.conf regexp="{{ item }}" insertbefore="^\<\/VirtualHost\>" line="{{ item }}"
   with_items:
-    - '  php_value auto_prepend_file /var/www/xhprof_html/external/header.php'
+    - '  php_value auto_prepend_file {{ apache2_docroot }}/xhprof_html/external/header.php'
     - '</VirtualHost>'
   when: xhprof_include_present.stdout.find('auto_prepend') == -1
   sudo: true
@@ -116,5 +116,5 @@
     - restart apache2
 
 - name: ensure xhprof directory permissions
-  file: path=/var/www/xhprof_html mode=0777 recurse=yes
+  file: path={{ apache2_docroot }}/xhprof_html mode=0777 recurse=yes
   sudo: true

--- a/vlad/playbooks/roles/xhprof/tasks/redhat_xhprof.yml
+++ b/vlad/playbooks/roles/xhprof/tasks/redhat_xhprof.yml
@@ -37,10 +37,10 @@
 
 - name: get xhprof_html package
   git:
-    repo: https://github.com/preinheimer/xhprof
-    dest: /var/www/xhprof_html
-    update: no
-    depth: 1
+    repo= https://github.com/preinheimer/xhprof
+    dest= {{ apache2_docroot }}/xhprof_html
+    update= no
+    depth= 1
   sudo: true
 
 - name: create xhprof_html application database
@@ -54,15 +54,15 @@
    - localhost
 
 - name: copy SQL install script
-  copy: src=install.mysql dest=/var/www/xhprof_html/install.sql
+  copy: src=install.mysql dest={{ apache2_docroot }}/xhprof_html/install.sql
   sudo: true
   
 - name: copy configuration file
-  template: src=xhprof_config_php.j2 dest=/var/www/xhprof_html/xhprof_lib/config.php
+  template: src=xhprof_config_php.j2 dest={{ apache2_docroot }}/xhprof_html/xhprof_lib/config.php
   sudo: true
 
 - name: run SQL install script
-  shell: mysql --user={{ dbuser }} --password={{ dbpass }} xhprof < /var/www/xhprof_html/install.sql
+  shell: mysql --user={{ dbuser }} --password={{ dbpass }} xhprof < {{ apache2_docroot }}/xhprof_html/install.sql
   sudo: true
 
 - name: check virtual host for Xhprof include
@@ -75,7 +75,7 @@
 - name: add virtual server item if include not found
   lineinfile: dest=/etc/httpd/vhosts/{{ webserver_hostname }}.conf regexp="{{ item }}" insertbefore="^\<\/VirtualHost\>" line="{{ item }}"
   with_items:
-    - '  php_value auto_prepend_file /var/www/xhprof_html/external/header.php'
+    - '  php_value auto_prepend_file {{ apache2_docroot }}/xhprof_html/external/header.php'
     - '</VirtualHost>'
   when: xhprof_include_present.stdout.find('auto_prepend') == -1
   sudo: true
@@ -89,5 +89,5 @@
     - restart httpd
 
 - name: ensure Xhprof directory permissions
-  file: path=/var/www/xhprof_html mode=0777 recurse=yes
+  file: path={{ apache2_docroot }}/xhprof_html mode=0777 recurse=yes
   sudo: true

--- a/vlad/playbooks/roles/xhprof/templates/apache_xhprof_vhost.j2
+++ b/vlad/playbooks/roles/xhprof/templates/apache_xhprof_vhost.j2
@@ -2,9 +2,9 @@
   ServerAdmin {{ admin_mail }}
   ServerName xhprof.{{ webserver_hostname }}
 
-  DocumentRoot /var/www/xhprof_html/xhprof_html
+  DocumentRoot {{ apache2_docroot }}/xhprof_html/xhprof_html
 
-  <Directory "/var/www/xhprof_html/xhprof_html/">
+  <Directory "{{ apache2_docroot }}/xhprof_html/xhprof_html/">
     Options FollowSymLinks MultiViews
     AllowOverride All
     Order allow,deny
@@ -19,8 +19,8 @@
     {% endif %}
   </Directory>
 
-  ErrorLog /var/www/site/logs/xhprof.error.log
+  ErrorLog {{ apache2_docroot }}/logs/xhprof.error.log
 
   LogLevel warn
-  CustomLog /var/www/site/logs/xhprof.access.log combined
+  CustomLog {{ apache2_docroot }}/logs/xhprof.access.log combined
 </VirtualHost>

--- a/vlad/playbooks/site.yml
+++ b/vlad/playbooks/site.yml
@@ -5,6 +5,8 @@
     - "./vars/defaults/general.yml"
     - "./vars/defaults/required.yml"
     - "./vars/defaults/install.yml"
+    - [ "vars/families/{{ ansible_os_family }}/all.yml", "vars/defaults/os.yml" ]
+    - [ "vars/distributions/{{ ansible_distribution_release }}/all.yml", "vars/defaults/os.yml" ]
     - [ "../../settings/vlad_settings.yml", "../../../settings/vlad_settings.yml", "../settings.yml", "vars/dummy_settings.yml" ]
     - [ "../../settings/vlad_local_settings.yml", "../../../settings/vlad_local_settings.yml", "../local_settings.yml", "vars/dummy_settings.yml" ]
 
@@ -122,7 +124,7 @@
   post_tasks:
 
     - name: move default index.php file into docroot directory
-      template: src=templates/index.j2 dest=/var/www/site/docroot/index.php force=no
+      template: src=templates/index.j2 dest={{ apache2_docroot }}/drupal/index.php force=no
       when: add_index_file
 
     # Run post provisioning tests to ensure everything has been provisioned correctly.

--- a/vlad/playbooks/templates/index.j2
+++ b/vlad/playbooks/templates/index.j2
@@ -74,7 +74,7 @@
         <h4>Build your own site</h4>
         <p>Out of the box Vlad is ready to run a Drupal site. Simply put the code in the <var>{{ host_synced_folder }}</var> directory and run either use the >web installer or install the site using drush:</p>
         <pre class="prettyprint linenums">
-$ cd /var/www/site/{{ host_synced_folder }}
+$ cd {{ apache2_docroot }}/{{ host_synced_folder }}
 $ drush site-install profile_name --db-url=mysql://{{ dbuser }}:{{ dbpass }}@localhost/{{ dbname }} --account-name=admin --account-pass=password --yes
 </pre>
 
@@ -84,13 +84,13 @@ $ drush site-install profile_name --db-url=mysql://{{ dbuser }}:{{ dbpass }}@loc
 
         <p><strong>Drupal 7</strong> can be installed via the following script. This will download the latest copy of
         Drupal 7 and install it using the Standard profile onto the default database. The Overlay module is uninstalled.</p>
-        <pre class="prettyprint linenums">$ /var/www/drupal7_install.sh</pre>
+        <pre class="prettyprint linenums">$ {{ apache2_docroot }}/drupal7_install.sh</pre>
 
         <p><strong>Drupal 8</strong> can be installed via the following script. This will clone the latest version of
         Drupal 8 from the Drupal Git repository and install it using the Standard profile. The upshot of this is that
         you have a working version of the Drupal Git repository and so you can pull the latest copy and easy write
         patches.</p>
-        <pre class="prettyprint linenums">$ /var/www/drupal8_install.sh</pre>
+        <pre class="prettyprint linenums">$ {{ apache2_docroot }}/drupal8_install.sh</pre>
 
         <p>In both cases the user credentials are as follows:</p>
 
@@ -271,17 +271,17 @@ $ vagrant ssh
 
             <p>Install most current Drupal with either
             <code>
-                $ sh /var/www/drupal7_install.sh
+                $ sh {{ apache2_docroot }}/drupal7_install.sh
             </code>
 
             or Drupal 8
             <code>
-                $ sh /var/www/drupal8_install.sh
+                $ sh {{ apache2_docroot }}/drupal8_install.sh
             </code>
 
             <h4 id="moresites">Can I run more sites on the same box?</h4>
 
-            <p>Yes, it is easy to run several sites on the same box. You just put them in different folders in <var>/var/www/site/{{ host_synced_folder }}/</var>.
+            <p>Yes, it is easy to run several sites on the same box. You just put them in different folders in <var>{{ apache2_docroot }}/{{ host_synced_folder }}/</var>.
                 You can create new databases using <a
                         href="http://adminer.{{ webserver_hostname }}:8080/?username=vlad">Adminer</a></p>
 

--- a/vlad/playbooks/vars/defaults/os.yml
+++ b/vlad/playbooks/vars/defaults/os.yml
@@ -1,0 +1,5 @@
+---
+# OS defaults
+apache2_docroot: /var/www/html
+apache2_user: apache
+apache2_group: apache

--- a/vlad/playbooks/vars/defaults/vagrant.yml
+++ b/vlad/playbooks/vars/defaults/vagrant.yml
@@ -16,7 +16,7 @@ boxname: "vlad"
 
 # Synced folder paths
 # Document root (docroot)
-host_synced_folder: "./docroot"
+host_synced_folder: "./drupal"
 # Vlad aux (vlad_aux)
 aux_synced_folder: "./vlad_aux"
 
@@ -36,3 +36,9 @@ vm_memory: 1024
 # - "ubuntu12"
 # - "ubuntu14"
 vlad_os: "ubuntu14"
+
+# Apache 2 document root. For ubuntu12:
+#  apache2_docroot: "/var/www"
+# For ubuntu14 and centos66:
+apache2_docroot: "/var/www/html"
+  

--- a/vlad/playbooks/vars/distributions/precise/all.yml
+++ b/vlad/playbooks/vars/distributions/precise/all.yml
@@ -1,0 +1,3 @@
+---
+# Ubuntu Precise vars
+apache2_docroot: /var/www

--- a/vlad/playbooks/vars/distributions/trusty/all.yml
+++ b/vlad/playbooks/vars/distributions/trusty/all.yml
@@ -1,0 +1,2 @@
+---
+# Ubuntu Trusty vars

--- a/vlad/playbooks/vars/families/CentOS/all.yml
+++ b/vlad/playbooks/vars/families/CentOS/all.yml
@@ -1,0 +1,5 @@
+---
+# CentOS family vars
+apache2_pkg: httpd
+apache2_user: apache
+apache2_group: apache

--- a/vlad/playbooks/vars/families/Debian/all.yml
+++ b/vlad/playbooks/vars/families/Debian/all.yml
@@ -1,0 +1,5 @@
+---
+# Debian family vars
+apache2_pkg: httpd
+apache2_user: www-data
+apache2_group: www-data


### PR DESCRIPTION
For a clearer organization of the projects, this
1. adds OS-dependent variables (*apache2_docroot*, *apache_user* and *apache_group*) to conform to the OS standards
2. renames /var/www/site/docroot to {{ apache2_docroot }}/drupal

To mimic the value in Ansible, it also introduces a new variable to Vagrantfile (*apache2_docroot*).

It replaces all occurrences of /var/www, /var/www/site, /var/www/site/docroot throughout the code, with the aforementioned new variables.

Interestingly enough, this opens the door for reducing code duplication of the *_debian.yml and *_redhat.yml tasks files. It does so by using conditionals on ansible facts.
