### PR TITLE
Optimizations for Virtualbox provider. Some refactoring of Vagrantfile.

### DIFF
--- a/vlad/example.settings.yml
+++ b/vlad/example.settings.yml
@@ -14,6 +14,24 @@
 # http://vlad-docs.readthedocs.org/en/latest/usage/variables/
 #
 
+#
+# Virtualbox params
+#
+
+# vm_cpus can be the number of CPUs, or "auto".
+  vm_cpus: 1
+
+# vm_memory can be explicit Megs, or "auto".
+  vm_memory: 1024
+
+# Chipset
+  vm_chipset: 'ich9'
+  
+# PAE, IOAPIC and ACPI
+  vm_pae: 'on'
+  vm_acpi: 'on'
+  vm_ioapic: 'on'
+  
 # Webserver settings
   webserver_hostname: 'drupal.local'
   webserver_hostname_aliases: 

--- a/vlad/playbooks/vars/defaults/vagrant.yml
+++ b/vlad/playbooks/vars/defaults/vagrant.yml
@@ -14,6 +14,24 @@ webserver_hostname_aliases:
 boxipaddress: "192.168.100.100"
 boxname: "vlad"
 
+#
+# Virtualbox params
+#
+
+# vm_cpus can be the number of CPUs, or "auto".
+vm_cpus: 1
+
+# vm_memory can be explicit Megs, or "auto".
+vm_memory: 1024
+
+# Chipset
+vm_chipset: 'ich9'
+  
+# PAE, IOAPIC and ACPI
+vm_pae: 'on'
+vm_acpi: 'on'
+vm_ioapic: 'on'
+  
 # Synced folder paths
 # Document root (docroot)
 host_synced_folder: "./docroot"


### PR DESCRIPTION
## Optimizations for Virtualbox provider
1. chipset set to [ICH9](http://www.virtualbox.org/manual/ch03.html#settings-motherboard) (instead of the older default PIIX3)
2. [IOAPIC and ACPI](http://www.virtualbox.org/manual/ch03.html#settings-motherboard) turned ON (required by 64bit OSes)
3. [PAE] (http://www.virtualbox.org/manual/ch03.html#settings-processor) turned on (required by Ubuntu)
4. [UTC](http://www.virtualbox.org/manual/ch03.html#settings-motherboard) (useful for Ubuntu)
5. Set the proper ostype. This may not have any real impact, it just annoyed me to see a different OS name in the VBOX GUI :-) #obsessive.
6. Switched to *virtio drivers* for faster network use.

## Some refactoring of Vagrantfile
I've removed the check for the --provider flag, since it wasn't making any difference (not being used). I've also rearranged the IF block.

## Defaults updated
1. Change CPU default value to 1. I've seen 2 CPUs is too much and actually worse than 1. In my box I get momentaneous freezes with 2 CPUs. 
2. I updated vagrant.yml and example.settings.yml to the extent of this issue.

Note:
*This is a fix for [#200].*
