### PR TITLE
Tweaked mysql rulebook so that connection via 127.0.0.1 is possible

### DIFF
--- a/vlad/playbooks/roles/mysql/tasks/mysql.yml
+++ b/vlad/playbooks/roles/mysql/tasks/mysql.yml
@@ -96,7 +96,7 @@
 - name: secure the MySQL root user for localhost
   mysql_user: name="root" password="{{ mysql_root_password }}" host="localhost" login_user=root login_password="{{ mysql_root_password }}"
 
-- name: allow root remote access on boxipaddress
+- name: allow root remote access on 127.0.0.1
   mysql_user: name="root" password="{{ mysql_root_password }}" priv="*.*:ALL,GRANT" host="127.0.0.1" login_user=root login_password="{{ mysql_root_password }}"
 
 - name: remove the MySQL test database

--- a/vlad/playbooks/roles/mysql/tasks/mysql.yml
+++ b/vlad/playbooks/roles/mysql/tasks/mysql.yml
@@ -97,7 +97,7 @@
   mysql_user: name="root" password="{{ mysql_root_password }}" host="localhost" login_user=root login_password="{{ mysql_root_password }}"
 
 - name: allow root remote access on boxipaddress
-  mysql_user: name="root" password="{{ mysql_root_password }}" priv="*.*:ALL,GRANT" host="{{ boxipaddress }}" login_user=root login_password="{{ mysql_root_password }}"
+  mysql_user: name="root" password="{{ mysql_root_password }}" priv="*.*:ALL,GRANT" host="127.0.0.1" login_user=root login_password="{{ mysql_root_password }}"
 
 - name: remove the MySQL test database
   mysql_db: db=test state=absent login_user=root login_password={{ mysql_root_password }}

--- a/vlad/playbooks/roles/mysql/tasks/mysql.yml
+++ b/vlad/playbooks/roles/mysql/tasks/mysql.yml
@@ -99,6 +99,9 @@
 - name: allow root remote access on 127.0.0.1
   mysql_user: name="root" password="{{ mysql_root_password }}" priv="*.*:ALL,GRANT" host="127.0.0.1" login_user=root login_password="{{ mysql_root_password }}"
 
+- name: allow root remote access on boxipaddress
+  mysql_user: name="root" password="{{ mysql_root_password }}" priv="*.*:ALL,GRANT" host="{{ boxipaddress }}" login_user=root login_password="{{ mysql_root_password }}"
+
 - name: remove the MySQL test database
   mysql_db: db=test state=absent login_user=root login_password={{ mysql_root_password }}
 


### PR DESCRIPTION
In order to connect to the DB (after SSH'ing in), this host needs to be set to 127.0.0.1, not the box IP.  This was tested against connecting to the DB on PHP Storm