### PR TITLE
Fix Drupal8 requirement for xdebug.max_nesting_level

### DIFF
--- a/vlad/playbooks/roles/php/templates/php_apache2_xdebug.ini.j2
+++ b/vlad/playbooks/roles/php/templates/php_apache2_xdebug.ini.j2
@@ -9,6 +9,6 @@ xdebug.profiler_enable=0
 xdebug.profiler_output_dir=/tmp/xdebug_profiles
 xdebug.profiler_enable_trigger=1
 xdebug.profiler_output_name=cachegrind.out.%p
-xdebug.max_nesting_level=200
+xdebug.max_nesting_level=256
 
 ; {{ ansible_managed }}


### PR DESCRIPTION
Here is a fix for #224 issue.
Fixing Drupal8 requirement for xdebug.max_nesting_level.