### PR TITLE
Update dest property for search_api_solr, incorrectly mixing syntax

### DIFF
--- a/vlad/playbooks/roles/solr/tasks/debian_solr.yml
+++ b/vlad/playbooks/roles/solr/tasks/debian_solr.yml
@@ -142,7 +142,7 @@
 - name: get Drupal solr integration via search_api_solr
   git:
     repo: http://git.drupal.org/project/{{ drupal_solr_package }}.git
-    dest: dest=/home/{{ user }}/drupal_solr
+    dest: /home/{{ user }}/drupal_solr
     version: 7.x-1.6
     depth: 1
   when: drupal_solr_package == "search_api_solr"

--- a/vlad/playbooks/roles/solr/tasks/redhat_solr.yml
+++ b/vlad/playbooks/roles/solr/tasks/redhat_solr.yml
@@ -142,7 +142,7 @@
 - name: get Drupal solr integration via search_api_solr
   git:
     repo: http://git.drupal.org/project/{{ drupal_solr_package }}.git
-    dest: dest=/home/{{ user }}/drupal_solr
+    dest: /home/{{ user }}/drupal_solr
     version: 7.x-1.6
     depth: 1
   when: drupal_solr_package == "search_api_solr"


### PR DESCRIPTION
Trying to set up Solr using the search_api_solr config files, the syntax appears to have been changed from a single-line (using =) to a multi-line (using key: value). This one has been incorrectly converted.

Patch for both debian and RH.