### PR TITLE
Resolving issue #295 by installing Ruby earlier.

### DIFF
--- a/vlad_guts/playbooks/site.yml
+++ b/vlad_guts/playbooks/site.yml
@@ -96,6 +96,8 @@
 
     - role: base
 
+    - { role: ruby, tags: ["ruby"], when: "ruby_install" }
+
     - { role: samba, tags: ["windows"], when: "is_windows" }
 
     - { role: apache, tags: ["apache"], when: "apache_install" }
@@ -136,8 +138,6 @@
     - { role: solr, tags: ["solr"], when: "solr_install" }
 
     - { role: munin, tags: ["munin"], when: "munin_install" }
-
-    - { role: ruby, tags: ["ruby"], when: "ruby_install" }
 
     - { role: mailcatcher, tags: ["mailcatcher"], when: "mailcatcher_install" }
 


### PR DESCRIPTION
In trying to resolve the Ruby install issue, I started simplifying and noticed that if I only installed Ruby and set all the other roles to `false`, then Ruby would install cleanly. From there, I just moved the installation of the Ruby role to earlier in the site.yml file and then everything seems to work together nicely again.

Granted, it would be nice to know *why* that works, but for the time being, I'm happy to just have the install process working cleanly again.