### PR TITLE
Adding options to allow for better innodb import performance.

### DIFF
--- a/vlad_guts/playbooks/roles/mysql/defaults/main.yml
+++ b/vlad_guts/playbooks/roles/mysql/defaults/main.yml
@@ -31,3 +31,9 @@ mysql_slow_query_log_status: 0
 mysql_slow_query_log_location: '/var/log/mysql/mysql-slow.log'
 mysqL_long_query_time: 2
 mysql_log_queries_not_using_indexes: false
+
+# Optional InnoDB settings that can be tweaked for better performance,
+# especially when importing large files. For more details, see:
+# http://bit.ly/20Vp76D
+innodb_flush_log_at_trx_commit: 1
+innodb_flush_method: fdatasync

--- a/vlad_guts/playbooks/roles/mysql/templates/mysql.my.cnf.j2
+++ b/vlad_guts/playbooks/roles/mysql/templates/mysql.my.cnf.j2
@@ -25,6 +25,12 @@ innodb_buffer_pool_size={{ innodb_buffer_pool_size }}
 innodb_file_per_table
 {% endif %}
 innodb_log_file_size={{ innodb_log_file_size }}
+{% if innodb_flush_log_at_trx_commit != 1 %}
+innodb_flush_log_at_trx_commit={{ innodb_flush_log_at_trx_commit }}
+{% endif %}
+{% if innodb_flush_method != 'fdatasync' %}
+innodb_flush_method={{ innodb_flush_method }}
+{% endif %}
 
 {% if skip_name_resolve == true %}
 #skip-name-resolve


### PR DESCRIPTION
I've been looking into ways to optimize the VLAD build time. This code change keeps the default behavior, but allows for some optional optimizations that can [improve InnoDB performance, especially when importing a large database](http://www.innovation-brigade.com/index.php?module=Content&type=user&func=display&tid=1&pid=2). More information specifically on `innodb_flush_log_at_trx_commit` can be found in [Drupal core issue #817398](https://www.drupal.org/node/817398).