### PR TITLE
Remove ansible ssh key config in default ansible settings

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,6 @@
 [defaults]
 log_path=vlad_guts/ansible.log
 ansible_ssh_user=vagrant
-ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key
 host_key_checking=false
 roles_path=vlad_guts/playbooks/ext_roles
 hostfile=./vlad_guts/host.ini


### PR DESCRIPTION
This is not required since vagrant passes the key on the command line.