### PR TITLE
Use an extra var for inventory directory.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -336,7 +336,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         info "Creating " + vlad_hosts_file
         FileUtils.cp(dir_ancestors[0] + "/vlad_guts/playbooks/templates/host.j2 ", vlad_hosts_file)
       else
-        run 'ansible-playbook -i ' + boxipaddress + ', ' + dir_ancestors[0] + '/vlad_guts/playbooks/local_up.yml --extra-vars "local_ip_address=' + boxipaddress + '"'
+        run 'ansible-playbook -i ' + boxipaddress + ', ' + dir_ancestors[0] + '/vlad_guts/playbooks/local_up.yml --extra-vars "local_ip_address=' + boxipaddress + '" --extra-vars "vlad_local_inventory_dir=' + dir_ancestors[0] + '/vlad_guts"'
       end
   end
 

--- a/vlad_guts/playbooks/local_up.yml
+++ b/vlad_guts/playbooks/local_up.yml
@@ -17,8 +17,12 @@
     set_fact: inventory_dir=".."
     when: inventory_dir is not defined
 
+  - name: set local inventory directory
+    set_fact: vlad_host_inventory_dir='{{ vlad_local_inventory_dir }}'
+    delegate_to: 127.0.0.1
+
   - name: local actions | create local host.ini file
-    template: src=templates/host.j2 dest="{{ inventory_dir }}/host.ini"
+    template: src=templates/host.j2 dest="{{ vlad_host_inventory_dir }}/host.ini"
     delegate_to: 127.0.0.1
 
   # SSH identities


### PR DESCRIPTION
This does away with the concept of inventory directory entirely. After all:

- We are operating locally.
- The Vagrantfile already knows what directory we are in. We use this value elsewhere
- So why not just pass it into Ansible?
- The trick, then, is that we need to shuttle that variable from the host scope to our
local 127.0.0.1 scope. We do that with delegate_to.

I have tested this, and it works great! I'm not sure if this is as clean of a fix as
you want, but it's a better stopgap than what we have now. Refs #324.