### PR TITLE
Use dest relative path to create local host.ini file

### DIFF
--- a/vlad_guts/playbooks/local_up.yml
+++ b/vlad_guts/playbooks/local_up.yml
@@ -14,7 +14,7 @@
     when: local_ip_address is not defined
 
   - name: local actions | create local host.ini file
-    template: src=templates/host.j2 dest=../host.ini
+    template: src=templates/host.j2 dest=./vlad_guts/host.ini
     delegate_to: 127.0.0.1
 
   # SSH identities


### PR DESCRIPTION
Fix for issue #340 

The ansible template module expands relative paths for a template `dest` option as relative to the destination, not relative to the playbook. This means relative to the `Vagrantfile` path for the purposes of this playbook, which is using the `ansible` provisioner to execute commands on the Vagrant Host machine.

See documentation at:
- [Ansible template_module options](http://docs.ansible.com/ansible/template_module.html#options)
- [Ansible and Vagrant](https://www.vagrantup.com/docs/provisioning/ansible_intro.html)

