### PR TITLE
Add Github contribution guidelines file

### DIFF
--- a/CONTIRBUTING.md
+++ b/CONTIRBUTING.md
@@ -8,7 +8,7 @@ If you haven't already, please take a look at the [Vlad documentation][vlad-docs
 Issues
 ------
 
-If you find a bug or want to improve Vlad in some way then open up an [issue](https://github.com/hashbangcode/vlad/issues).
+If you find a bug or want to improve Vlad in some way then open up an [issue][issues].
 
 Pull Requests
 -------------
@@ -28,11 +28,11 @@ Standards
 The following is a list of standards that should be adhered to when contributing to Vlad.
 
 - [Task naming convention][naming_convention]
-
 - [Task attribute order convention][order_convention]
 
 
 [vlad-docs]: http://vlad-docs.readthedocs.org/
+[issues]: https://github.com/hashbangcode/vlad/issues
 [naming_convention]: http://vlad-docs.readthedocs.org/en/latest/contributing/naming_convention/
 [order_convention]: http://vlad-docs.readthedocs.org/en/latest/contributing/order_convention/
 

--- a/CONTIRBUTING.md
+++ b/CONTIRBUTING.md
@@ -10,12 +10,12 @@ Issues
 
 If you find a bug or want to improve Vlad in some way then open up an [issue][issues].
 
+The `dev` branch contains the latest development code, so please test your bug or improvement there first to see if it has already been fixed, before you take the time to investigate it yourself.
+
 Pull Requests
 -------------
 
 Pull requests to the project are welcome but **should not** be done to the `master` branch. All pull requests **must** be created against the `dev` branch. 
-
-The `dev` branch contains the latest development code, so please test your bug there first to see if it has already been fixed, before you take the time to investigate it yourself. 
 
 Tests
 -----

--- a/CONTIRBUTING.md
+++ b/CONTIRBUTING.md
@@ -1,0 +1,38 @@
+How to Contribute
+=================
+
+I'm really glad you're reading this, because we love taking contributions from people like you, who use and love Vlad like we do. 
+
+If you haven't already, please take a look at the [Vlad documentation][vlad-docs]. We could use your help there too if you have the time. 
+
+Issues
+------
+
+If you find a bug or want to improve Vlad in some way then open up an [issue](https://github.com/hashbangcode/vlad/issues).
+
+Pull Requests
+-------------
+
+Pull requests to the project are welcome but **should not** be done to the `master` branch. All pull requests **must** be created against the `dev` branch. 
+
+The `dev` branch contains the latest development code, so please test your bug there first to see if it has already been fixed, before you take the time to investigate it yourself. 
+
+Tests
+-----
+
+In order to ensure that things run correctly all software installed should have at least one test.
+
+Standards
+---------
+
+The following is a list of standards that should be adhered to when contributing to Vlad.
+
+- [Task naming convention][naming_convention]
+
+- [Task attribute order convention][order_convention]
+
+
+[vlad-docs]: http://vlad-docs.readthedocs.org/
+[naming_convention]: http://vlad-docs.readthedocs.org/en/latest/contributing/naming_convention/
+[order_convention]: http://vlad-docs.readthedocs.org/en/latest/contributing/order_convention/
+


### PR DESCRIPTION
Created a `CONTRIBUTING` file as per the [Github pattern](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) so that the guidelines appear automatically for those creating a pull request through Github. 

The format and content was taken from the [Vlad documentation](http://vlad-docs.readthedocs.org/en/latest/contributing/contributing/) project with formatting changes and additions based on good practice. 

Fixes #342 