### PR TITLE
Improved bash prompt hints

### DIFF
--- a/vlad_guts/playbooks/roles/bling/defaults/main.yml
+++ b/vlad_guts/playbooks/roles/bling/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
 bling_shell_prompt: true
+bling_shell_prompt_git_upstream: false

--- a/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
+++ b/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
@@ -92,7 +92,7 @@ bash_prompt() {
 
    [ $UID -eq "0" ] && UC=$R     # root's color
 
-   PS1="${TITLEBAR}\n${EMK}[${UC}\u${EMK}@${MC}\h ${PC}\${NEW_PWD}${GC}\${GIT_PS1}${DC}\${DRUSH_PS1}${EMK}]\n${UC}\\$ ${NONE}"
+   PS1="${TITLEBAR}\n${EMK}✝ ${UC}\u${EMK}@${MC}\h ${EMK}✝${PC}\${NEW_PWD}${GC}\${GIT_PS1}${DC}\${DRUSH_PS1}\n${UC}\\$ ${NONE}"
    # without colors: PS1="[\u@\h \${NEW_PWD}\${GIT_PS1}\${DRUSH_PS1}]\\$ "
    # extra backslash in front of closing \$ to make bash colorize the prompt
 }

--- a/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
+++ b/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
@@ -1,7 +1,7 @@
 # vim: ft=sh ts=4 sw=4
 # Functions to generate a pretty useful bash prompt
 
-# Check for interactive bash 
+# Check for interactive bash
 [ -z "$BASH_VERSION" -a -z "$KSH_VERSION" -o -z "$PS1" ] && return
 
 #
@@ -15,28 +15,28 @@
 #
 bash_prompt_command() {
    # How many characters of the $PWD should be kept
-   local pwdmaxlen=25
+   local pwdmaxlen=25;
    # Indicate that there has been dir truncation
-   local trunc_symbol=".."
-   local dir=${PWD##*/}
-   pwdmaxlen=$(( ( pwdmaxlen < ${#dir} ) ? ${#dir} : pwdmaxlen ))
-   NEW_PWD=${PWD/#$HOME/\~}
-   local pwdoffset=$(( ${#NEW_PWD} - pwdmaxlen ))
+   local trunc_symbol="..";
+   local dir=${PWD##*/};
+   pwdmaxlen=$(( ( pwdmaxlen < ${#dir} ) ? ${#dir} : pwdmaxlen ));
+   NEW_PWD=${PWD/#$HOME/\~};
+   local pwdoffset=$(( ${#NEW_PWD} - pwdmaxlen ));
    if [ ${pwdoffset} -gt "0" ];
    then
-      NEW_PWD=${NEW_PWD:$pwdoffset:$pwdmaxlen}
-      NEW_PWD=${trunc_symbol}/${NEW_PWD#*/}
+      NEW_PWD=${NEW_PWD:$pwdoffset:$pwdmaxlen};
+      NEW_PWD=${trunc_symbol}/${NEW_PWD#*/};
    fi
    # Display git prompt if available.
    GIT_PS1='';
-   if [ $(type -t "__git_ps1") ]; 
+   if [ $(type -t "__git_ps1") ];
    then
       GIT_PS1_SHOWCOLORHINTS='';
       GIT_PS1=$(__git_ps1);
    fi
-   # Display drush prompt if available. 
+   # Display drush prompt if available.
    DRUSH_PS1='';
-   if [ $(type -t "__drush_ps1") ]; 
+   if [ $(type -t "__drush_ps1") ];
    then
       DRUSH_PS1_SHOWCOLORHINTS='';
       DRUSH_PS1=$(__drush_ps1 " [%s]");
@@ -52,43 +52,45 @@ bash_prompt() {
          local TITLEBAR="";
          ;;
    esac
-   local NONE="\[\033[0m\]"      # unsets color to term's fg color
+
+   local NONE="\[\033[0m\]";  # unset fg colour
 
    # regular colors
-   local K="\[\033[0;30m\]"      # black
-   local R="\[\033[0;31m\]"      # red
-   local G="\[\033[0;32m\]"      # green
-   local Y="\[\033[0;33m\]"      # yellow
-   local B="\[\033[0;34m\]"      # blue
-   local M="\[\033[0;35m\]"      # magenta
-   local C="\[\033[0;36m\]"      # cyan
-   local W="\[\033[0;37m\]"      # white
+   local K="\[\033[0;30m\]";  # black
+   local R="\[\033[0;31m\]";  # red
+   local G="\[\033[0;32m\]";  # green
+   local Y="\[\033[0;33m\]";  # yellow
+   local B="\[\033[0;34m\]";  # blue
+   local M="\[\033[0;35m\]";  # magenta
+   local C="\[\033[0;36m\]";  # cyan
+   local W="\[\033[0;37m\]";  # white
 
    # emphasized (bolded) colors
-   local EMK="\[\033[1;30m\]"
-   local EMR="\[\033[1;31m\]"
-   local EMG="\[\033[1;32m\]"
-   local EMY="\[\033[1;33m\]"
-   local EMB="\[\033[1;34m\]"
-   local EMM="\[\033[1;35m\]"
-   local EMC="\[\033[1;36m\]"
-   local EMW="\[\033[1;37m\]"
+   local EMK="\[\033[1;30m\]";
+   local EMR="\[\033[1;31m\]";
+   local EMG="\[\033[1;32m\]";
+   local EMY="\[\033[1;33m\]";
+   local EMB="\[\033[1;34m\]";
+   local EMM="\[\033[1;35m\]";
+   local EMC="\[\033[1;36m\]";
+   local EMW="\[\033[1;37m\]";
 
    # background colors
-   local BGK="\[\033[40m\]"
-   local BGR="\[\033[41m\]"
-   local BGG="\[\033[42m\]"
-   local BGY="\[\033[43m\]"
-   local BGB="\[\033[44m\]"
-   local BGM="\[\033[45m\]"
-   local BGC="\[\033[46m\]"
-   local BGW="\[\033[47m\]"
+   local BGK="\[\033[40m\]";
+   local BGR="\[\033[41m\]";
+   local BGG="\[\033[42m\]";
+   local BGY="\[\033[43m\]";
+   local BGB="\[\033[44m\]";
+   local BGM="\[\033[45m\]";
+   local BGC="\[\033[46m\]";
+   local BGW="\[\033[47m\]";
 
-   local UC=$G                   # user name's color
-   local MC=$C                   # machine name's color
-   local PC=$EMB                 # path's color
-   local GC=$EMM                 # git information color
-   local DC=$EMY                 # Drupal information color
+   local UC=$G;    # user name's color
+   local MC=$C;    # machine name's color
+   local PC=$EMB;  # path's color
+   local GC=$EMM;  # git information color
+   local DC=$EMY;  # Drupal information color
+
 
    [ $UID -eq "0" ] && UC=$R     # root's color
 
@@ -97,7 +99,7 @@ bash_prompt() {
    # extra backslash in front of closing \$ to make bash colorize the prompt
 }
 
-# Enable the prompt. 
+# Enable the prompt.
 # Execute this command every time a prompt is drawn
 export PROMPT_COMMAND=bash_prompt_command
 # Define the text to display beside the prompt

--- a/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
+++ b/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
@@ -46,7 +46,7 @@ bash_prompt_command() {
 bash_prompt() {
    case $TERM in
       xterm*|rxvt*)
-         local TITLEBAR='\[\033]0;\u:${NEW_PWD}${GIT_PS1}${DRUSH_PS1}\007\]';
+         local TITLEBAR='\[\033]0;\h:${NEW_PWD}${GIT_PS1}${DRUSH_PS1}\007\]';
          ;;
       *)
          local TITLEBAR="";

--- a/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
+++ b/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
@@ -85,16 +85,18 @@ bash_prompt() {
    local BGC="\[\033[46m\]";
    local BGW="\[\033[47m\]";
 
+   local AC=$EMK;  # apotropaic symbol color
    local UC=$G;    # user name's color
    local MC=$C;    # machine name's color
    local PC=$EMB;  # path's color
    local GC=$EMM;  # git information color
    local DC=$EMY;  # Drupal information color
 
+   local APOT='✝'; # apotropaic symbol
 
    [ $UID -eq "0" ] && UC=$R     # root's color
 
-   PS1="${TITLEBAR}\n${EMK}✝ ${UC}\u${EMK}@${MC}\h ${EMK}✝${PC}\${NEW_PWD}${GC}\${GIT_PS1}${DC}\${DRUSH_PS1}\n${UC}\\$ ${NONE}"
+   PS1="${TITLEBAR}\n${AC}${APOT} ${UC}\u${EMK}@${MC}\h ${AC}${APOT} ${PC}\${NEW_PWD}${GC}\${GIT_PS1}${DC}\${DRUSH_PS1}\n${UC}\\$ ${NONE}"
    # without colors: PS1="[\u@\h \${NEW_PWD}\${GIT_PS1}\${DRUSH_PS1}]\\$ "
    # extra backslash in front of closing \$ to make bash colorize the prompt
 }

--- a/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
+++ b/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
@@ -1,0 +1,106 @@
+# vim: ft=sh ts=4 sw=4
+# Functions to generate a pretty useful bash prompt
+
+# Check for interactive bash 
+[ -z "$BASH_VERSION" -a -z "$KSH_VERSION" -o -z "$PS1" ] && return
+
+#
+# Fancy PWD display function
+#
+# The home directory (HOME) is replaced with a ~
+# The last pwdmaxlen characters of the PWD are displayed
+# Leading partial directory names are striped off
+# /home/me/stuff          -> ~/stuff               if USER=me
+# /usr/share/big_dir_name -> ../share/big_dir_name if pwdmaxlen=20
+#
+bash_prompt_command() {
+   # How many characters of the $PWD should be kept
+   local pwdmaxlen=25
+   # Indicate that there has been dir truncation
+   local trunc_symbol=".."
+   local dir=${PWD##*/}
+   pwdmaxlen=$(( ( pwdmaxlen < ${#dir} ) ? ${#dir} : pwdmaxlen ))
+   NEW_PWD=${PWD/#$HOME/\~}
+   local pwdoffset=$(( ${#NEW_PWD} - pwdmaxlen ))
+   if [ ${pwdoffset} -gt "0" ];
+   then
+      NEW_PWD=${NEW_PWD:$pwdoffset:$pwdmaxlen}
+      NEW_PWD=${trunc_symbol}/${NEW_PWD#*/}
+   fi
+   # Display git prompt if available.
+   GIT_PS1='';
+   if [ $(type -t "__git_ps1") ]; 
+   then
+      GIT_PS1_SHOWCOLORHINTS='';
+      GIT_PS1=$(__git_ps1);
+   fi
+   # Display drush prompt if available. 
+   DRUSH_PS1='';
+   if [ $(type -t "__drush_ps1") ]; 
+   then
+      DRUSH_PS1_SHOWCOLORHINTS='';
+      DRUSH_PS1=$(__drush_ps1 " [%s]");
+   fi
+}
+
+bash_prompt() {
+   case $TERM in
+      xterm*|rxvt*)
+         local TITLEBAR='\[\033]0;\u:${NEW_PWD}${GIT_PS1}${DRUSH_PS1}\007\]';
+         ;;
+      *)
+         local TITLEBAR="";
+         ;;
+   esac
+   local NONE="\[\033[0m\]"      # unsets color to term's fg color
+
+   # regular colors
+   local K="\[\033[0;30m\]"      # black
+   local R="\[\033[0;31m\]"      # red
+   local G="\[\033[0;32m\]"      # green
+   local Y="\[\033[0;33m\]"      # yellow
+   local B="\[\033[0;34m\]"      # blue
+   local M="\[\033[0;35m\]"      # magenta
+   local C="\[\033[0;36m\]"      # cyan
+   local W="\[\033[0;37m\]"      # white
+
+   # emphasized (bolded) colors
+   local EMK="\[\033[1;30m\]"
+   local EMR="\[\033[1;31m\]"
+   local EMG="\[\033[1;32m\]"
+   local EMY="\[\033[1;33m\]"
+   local EMB="\[\033[1;34m\]"
+   local EMM="\[\033[1;35m\]"
+   local EMC="\[\033[1;36m\]"
+   local EMW="\[\033[1;37m\]"
+
+   # background colors
+   local BGK="\[\033[40m\]"
+   local BGR="\[\033[41m\]"
+   local BGG="\[\033[42m\]"
+   local BGY="\[\033[43m\]"
+   local BGB="\[\033[44m\]"
+   local BGM="\[\033[45m\]"
+   local BGC="\[\033[46m\]"
+   local BGW="\[\033[47m\]"
+
+   local UC=$G                   # user name's color
+   local MC=$C                   # machine name's color
+   local PC=$EMB                 # path's color
+   local GC=$EMM                 # git information color
+   local DC=$EMY                 # Drupal information color
+
+   [ $UID -eq "0" ] && UC=$R     # root's color
+
+   PS1="${TITLEBAR}\n${EMK}[${UC}\u${EMK}@${MC}\h ${PC}\${NEW_PWD}${GC}\${GIT_PS1}${DC}\${DRUSH_PS1}${EMK}]\n${UC}\\$ ${NONE}"
+   # without colors: PS1="[\u@\h \${NEW_PWD}\${GIT_PS1}\${DRUSH_PS1}]\\$ "
+   # extra backslash in front of closing \$ to make bash colorize the prompt
+}
+
+# Enable the prompt. 
+# Execute this command every time a prompt is drawn
+export PROMPT_COMMAND=bash_prompt_command
+# Define the text to display beside the prompt
+bash_prompt
+# Clean-up the functions we no-longer require
+unset bash_prompt

--- a/vlad_guts/playbooks/roles/bling/tasks/main.yml
+++ b/vlad_guts/playbooks/roles/bling/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
 
-- name: Apotropaic shell prompt
+- name: Enable useful bash prompt
   lineinfile:
     dest: /home/{{ user }}/.bashrc
-    line: export PS1="✝ {{ boxname }} ✝ \w $ "
+    line: '[[ -f "${HOME}/.bash_prompt" ]] && . "${HOME}/.bash_prompt"'
+  when: bling_shell_prompt
+
+- name: Copy useful bash prompt
+  copy:
+    src: bash_prompt.sh
+    dest: /home/{{ user }}/.bash_prompt
+    force: no
   when: bling_shell_prompt

--- a/vlad_guts/playbooks/roles/bling/tasks/main.yml
+++ b/vlad_guts/playbooks/roles/bling/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: Enable useful bash prompt
+- name: Apotropaic bash prompt
   lineinfile:
     dest: /home/{{ user }}/.bashrc
     line: '[[ -f "${HOME}/.bash_prompt" ]] && . "${HOME}/.bash_prompt"'
   when: bling_shell_prompt
 
-- name: Copy useful bash prompt
+- name: Copy Apotropaic useful bash prompt
   copy:
     src: bash_prompt.sh
     dest: /home/{{ user }}/.bash_prompt

--- a/vlad_guts/playbooks/roles/bling/tasks/main.yml
+++ b/vlad_guts/playbooks/roles/bling/tasks/main.yml
@@ -12,3 +12,9 @@
     dest: /home/{{ user }}/.bash_prompt
     force: no
   when: bling_shell_prompt
+
+- name: Configure bash prompt git hint
+  lineinfile:
+    dest: /home/{{ user }}/.bashrc
+    line: export GIT_PS1_SHOWUPSTREAM={{ bling_shell_prompt_git_upstream | default('', true) }}
+  when: bling_shell_prompt

--- a/vlad_guts/playbooks/roles/drush_extras/tasks/main.yml
+++ b/vlad_guts/playbooks/roles/drush_extras/tasks/main.yml
@@ -39,6 +39,14 @@
   shell: drush init -y
   when: "{{ vlad_drush_installed_version_major | version_compare('8', '>=') }}"
 
+# drush bash completion and prompt (drush versions < 8)
+
+- name: Enable bash completion and prompt for Drush version < 8
+  command: >
+    cp -T {{ drush_install_path }}/drush.complete.sh /etc/bash_completion.d/drush
+    creates=/etc/bash_completion.d/drush
+  when: "{{ vlad_drush_installed_version_major | version_compare('8', '<') }}"
+  become: true
 
 # .drush_bashrc (drush versions < 8)
 


### PR DESCRIPTION
For your consideration: improved bash prompt "bling" that is consistent, useful and colourful. 

These changes configure and enable drush and git hints in the bash prompt and terminal title bar that work with all currently supported drush and git versions. They can be disabled using the existing Vlad variable `bling_shell_prompt`. 

So far tested with:

1. Ubuntu 14
    - drush 7.x
    - drush 8.x

Yet to be tested:

1. Ubuntu 14
    - drush 6.x
1. Centos
    - drush 6.x
    - drush 7.x
    - drush 8.x
