### PR TITLE
Enable vagrant-cachier for CentOS using Yum

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -136,7 +136,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     config.cache.auto_detect = false
 
-    if vlad_os == "centos66"
+    if vlad_os == "centos67"
       config.cache.enable :yum
     else
       config.cache.enable :apt


### PR DESCRIPTION
Fix the string match for CentOS so that vagrant-cachier is on once more when provisioning CentOS boxes with `vlad_os: centos67` in settings.