### PR TITLE
Bling bash prompt configuration settings

### DIFF
--- a/vlad_guts/playbooks/roles/bling/defaults/main.yml
+++ b/vlad_guts/playbooks/roles/bling/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
 
 bling_shell_prompt: true
-bling_shell_prompt_git_upstream: false
+bling_shell_prompt_hints:
+  - source: git
+    enable: true
+  - source: drush
+    enable: true

--- a/vlad_guts/playbooks/roles/bling/defaults/main.yml
+++ b/vlad_guts/playbooks/roles/bling/defaults/main.yml
@@ -4,5 +4,23 @@ bling_shell_prompt: true
 bling_shell_prompt_hints:
   - source: git
     enable: true
+    config:
+      - name: showColorHints
+        value: false
+      - name: showUpstream
+        value: false
+      - name: showDirtyState
+        value: false
+      - name: showStashState
+        value: false
+      - name: showUntrackedFiles
+        value: false
+      - name: stateSeparator
+        value: " "
+      - name: describe_style
+        value: false
   - source: drush
     enable: true
+    config:
+      - name: showColorHints
+        value: false

--- a/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
+++ b/vlad_guts/playbooks/roles/bling/files/bash_prompt.sh
@@ -29,16 +29,14 @@ bash_prompt_command() {
    fi
    # Display git prompt if available.
    GIT_PS1='';
-   if [ $(type -t "__git_ps1") ];
+   if [ $(type -t '__git_ps1') ] && [ -n "${BLING_PS1_SHOWGIT-}" ];
    then
-      GIT_PS1_SHOWCOLORHINTS='';
       GIT_PS1=$(__git_ps1);
    fi
    # Display drush prompt if available.
    DRUSH_PS1='';
-   if [ $(type -t "__drush_ps1") ];
+   if [ $(type -t '__drush_ps1') ] && [ -n "${BLING_PS1_SHOWDRUSH-}" ];
    then
-      DRUSH_PS1_SHOWCOLORHINTS='';
       DRUSH_PS1=$(__drush_ps1 " [%s]");
    fi
 }
@@ -46,7 +44,7 @@ bash_prompt_command() {
 bash_prompt() {
    case $TERM in
       xterm*|rxvt*)
-         local TITLEBAR='\[\033]0;\h:${NEW_PWD}${GIT_PS1}${DRUSH_PS1}\007\]';
+         local TITLEBAR='\[\033]0;\h:${NEW_PWD}${GIT_PS1-}${DRUSH_PS1-}\007\]';
          ;;
       *)
          local TITLEBAR="";
@@ -96,8 +94,8 @@ bash_prompt() {
 
    [ $UID -eq "0" ] && UC=$R     # root's color
 
-   PS1="${TITLEBAR}\n${AC}${APOT} ${UC}\u${EMK}@${MC}\h ${AC}${APOT} ${PC}\${NEW_PWD}${GC}\${GIT_PS1}${DC}\${DRUSH_PS1}\n${UC}\\$ ${NONE}"
-   # without colors: PS1="[\u@\h \${NEW_PWD}\${GIT_PS1}\${DRUSH_PS1}]\\$ "
+   PS1="${TITLEBAR}\n${AC}${APOT} ${UC}\u${EMK}@${MC}\h ${AC}${APOT} ${PC}\${NEW_PWD}${GC}\${GIT_PS1-}${DC}\${DRUSH_PS1-}\n${UC}\\$ ${NONE}"
+   # without colors: PS1="[\u@\h \${NEW_PWD}\${GIT_PS1-}\${DRUSH_PS1-}]\\$ "
    # extra backslash in front of closing \$ to make bash colorize the prompt
 }
 

--- a/vlad_guts/playbooks/roles/bling/tasks/main.yml
+++ b/vlad_guts/playbooks/roles/bling/tasks/main.yml
@@ -12,8 +12,9 @@
     line: '[[ -f "${HOME}/.bash_prompt" ]] && . "${HOME}/.bash_prompt"'
   when: bling_shell_prompt
 
-- name: Configure bash prompt git hint
+- name: Enable bash prompt hints
   lineinfile:
     dest: /home/{{ user }}/.bashrc
-    line: export GIT_PS1_SHOWUPSTREAM={{ bling_shell_prompt_git_upstream | default('', true) }}
-  when: bling_shell_prompt
+    line: "export BLING_PS1_SHOW{{ item.source | upper }}='{{ item.enable | default('', true) }}';"
+  with_items: "{{ bling_shell_prompt_hints }}"
+  when: (bling_shell_prompt and item.source is defined)

--- a/vlad_guts/playbooks/roles/bling/tasks/main.yml
+++ b/vlad_guts/playbooks/roles/bling/tasks/main.yml
@@ -18,3 +18,12 @@
     line: "export BLING_PS1_SHOW{{ item.source | upper }}='{{ item.enable | default('', true) }}';"
   with_items: "{{ bling_shell_prompt_hints }}"
   when: (bling_shell_prompt and item.source is defined)
+
+- name: Configure bash prompt hints
+  lineinfile:
+    dest: /home/{{ user }}/.bashrc
+    line: "export {{ item.0.source | upper }}_PS1_{{ item.1.name | upper }}='{{ item.1.value | default('', true) }}';"
+  with_subelements:
+    - "{{ bling_shell_prompt_hints }}"
+    - config
+  when: (bling_shell_prompt and item.0.enable)


### PR DESCRIPTION
## Description

Adds configuration settings for the Bling bash prompt:

- Turn on/off Drush hints
- Turn on/off Git hints
- Provide performant defaults for Git hint settings

## Remaining Tasks

1. Flatten the `config` hash structure from:
    
        config: 
          - name: foo
            value: bar

    to something like 

        config:
          - foo: bar

1. Write tests for these settings
1. Include updates to the documentation that describe each setting and its allowed values

## Related Issues

- #347 