### PR TITLE
Ensure allocated CPUs do not exceed physical cores

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -158,7 +158,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # sysctl returns Bytes and we need to convert to MB
     auto_memory = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 4
   elsif host =~ /linux/
-    auto_cpus = `nproc`.to_i
+    auto_cpus = `nproc`.to_i / 2
     # meminfo shows KB and we need to convert to MB
     auto_memory = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
   else


### PR DESCRIPTION
VirtualBox 4.3+ uses physical cores for virtualisation, not threaded cores. For most Linux hosts using an Intel x86_64 chipset the number of real cores will be half the number reported by `nproc`.

See issue #350