### PR TITLE
Remove username and password to force machine keys

### DIFF
--- a/vlad_guts/playbooks/roles/pantheon_import/defaults/main.yml
+++ b/vlad_guts/playbooks/roles/pantheon_import/defaults/main.yml
@@ -3,8 +3,7 @@
 # Pantheon Import settings
 
 vlad_pantheon_import: false
-vlad_pantheon_import_email: ''
-vlad_pantheon_import_password: ''
+vlad_pantheon_import_machine_key: ''
 vlad_pantheon_import_site: ''
 vlad_pantheon_import_env: ''
 vlad_pantheon_import_include_code: false

--- a/vlad_guts/playbooks/roles/pantheon_import/tasks/pantheon_import.yml
+++ b/vlad_guts/playbooks/roles/pantheon_import/tasks/pantheon_import.yml
@@ -3,8 +3,8 @@
 # Authenticate to Pantheon CLI. Don't do anything else if it fails,
 # but do ignore errors (this doesn't need to halt provisioning).
 # @todo: Run a terminus auth whoami first and don't mark anything changed if we are already logged in.
-- name: Log in to Pantheon
-  command: /usr/local/bin/terminus auth login "{{ vlad_pantheon_import_email }}" --password='{{ vlad_pantheon_import_password }}'
+- name: Log in to Pantheon with machine token
+  command: /usr/local/bin/terminus auth login --machine-token="{{ vlad_pantheon_import_machine_key }}"
   register: vlad_pantheon_auth_success
   ignore_errors: yes
 


### PR DESCRIPTION
Now that pantheon can use machine tokens, we should stop using username and password in the vlad_settings file. I created a separate pull request on https://github.com/hashbangcode/ansible-role-pantheon-cli/pull/5 to handle upgrading the CLI version.

Until that is implimented, you can override it in your vlad_settings.yml file with:

`pantheon_cli_version: 0.11.4`