### PR TITLE
Fix MySQL and Xdebug issues on 16.04

### DIFF
--- a/vlad_guts/playbooks/roles/mysql/tasks/mysql.yml
+++ b/vlad_guts/playbooks/roles/mysql/tasks/mysql.yml
@@ -65,6 +65,12 @@
   register: mysql_myconf_file
   become: yes
 
+# http://askubuntu.com/a/801950/36187
+- name: switch root to mysql_native_password plugin
+  command: mysql -e "update mysql.user set Plugin = 'mysql_native_password' where User='root'; FLUSH PRIVILEGES;"
+  become: yes
+  when: vlad_os == 'ubuntu16' and mysql_myconf_file.stat.exists == false
+
 # MySQL database setup, this does the equivalent of mysql_secure_installation.
 - name: set the root password
   mysql_user:

--- a/vlad_guts/playbooks/roles/php/tasks/debian_php.yml
+++ b/vlad_guts/playbooks/roles/php/tasks/debian_php.yml
@@ -66,7 +66,28 @@
     - restart apache2
   when: php_ppa == "php5-oldstable"
 
-- name: install PHP packages
+# Our 16.04 box seems to have php5.6 pre-installed or something. Make sure that
+# PHP 7.0 is the one to get assigned to Apache when configured.
+- name: ensure we only install one version of PHP
+  apt: pkg=php{{ item }}* state=absent autoremove=yes
+  with_items:
+    - '5.5'
+    - '5.6'
+    - '7.0'
+    - '7.1'
+  when:
+    - item != php_version
+    - php_ppa != "php5-oldstable"
+    - vlad_os == 'ubuntu16'
+
+- name: install PHP core package
+  apt: pkg={{ php_package }} state=latest update_cache=yes cache_valid_time=3600
+  become: true
+  notify:
+    - restart apache2
+  when: php_ppa != "php5-oldstable"
+
+- name: install other PHP packages
   apt: pkg={{ item }} state=latest update_cache=yes cache_valid_time=3600
   with_items:
    - "{{ php_package }}"

--- a/vlad_guts/playbooks/roles/xdebug/tasks/debian.yml
+++ b/vlad_guts/playbooks/roles/xdebug/tasks/debian.yml
@@ -1,7 +1,14 @@
 ---
-- name: Install Xdebug PHP component
+- name: Install Xdebug PHP component (PHP 5.x)
   apt: pkg=php5-xdebug state=installed
   register: xdebug_installed
+  when: php_version != '7.0' and php_version != '7.1'
+  become: true
+
+- name: Install Xdebug PHP component (PHP 7.x)
+  apt: pkg=php-xdebug state=installed
+  register: xdebug_installed
+  when: php_version == '7.0' or php_version == '7.1'
   become: true
 
 - name: Get first line of /etc/php5/apache2/conf.d/xdebug.ini
@@ -10,18 +17,42 @@
   register: xdebug_first_line
   become: true
 
-- name: Update Xdebug configuration file
+- name: Update Xdebug configuration file (PHP 5.3)
   template: src=php_apache2_xdebug.ini.j2 dest=/etc/php5/apache2/conf.d/xdebug.ini
   when: xdebug_installed.changed and php_version == '5.3'
   become: true
 
-- name: Get first line of /etc/php5/apache2/conf.d/xdebug.ini
+- name: Get first line of /etc/php5/mods-available/xdebug.ini
   command: head -n 1 /etc/php5/mods-available/xdebug.ini
-  when: xdebug_installed.changed and php_version != '5.3'
+  when: xdebug_installed.changed and php_version != '5.3' and php_version != '7.0' and php_version != '7.1' and vlad_os != 'ubuntu16'
   register: xdebug_first_line
   become: true
 
-- name: Update Xdebug configuration file
+- name: Get first line of /etc/php/7.0/mods-available/xdebug.ini
+  command: head -n 1 /etc/php/7.0/mods-available/xdebug.ini
+  when: xdebug_installed.changed and (php_version == '7.0' or php_version == '7.1') and vlad_os != 'ubuntu16'
+  register: xdebug_first_line
+  become: true
+
+- name: Get first line of /etc/php/{{ php_version }}/mods-available/xdebug.ini (Ubuntu 16.04)
+  command: head -n 1 /etc/php/7.0/mods-available/xdebug.ini
+  when: xdebug_installed.changed and vlad_os == 'ubuntu16'
+  register: xdebug_first_line
+  become: true
+
+- name: Update Xdebug configuration file (PHP 5.5/5.6)
   template: src=php_apache2_xdebug.ini.j2 dest=/etc/php5/mods-available/xdebug.ini
-  when: xdebug_installed.changed and php_version != '5.3'
+  when: xdebug_installed.changed and php_version != '5.3' and php_version != '7.0' and php_version != '7.1' and vlad_os != 'ubuntu16'
+  become: true
+
+- name: Update Xdebug configuration file (PHP 7.x)
+  template: src=php_apache2_xdebug.ini.j2 dest=/etc/php/{{ php_version }}/mods-available/xdebug.ini
+  when: xdebug_installed.changed and (php_version == '7.0' or php_version == '7.1') and vlad_os != 'ubuntu16'
+  become: true
+
+# Multiple PHP versions are available for Ubuntu 16.04, and the config structure
+# is normalized.
+- name: Update Xdebug configuration file (Ubuntu 16.04)
+  template: src=php_apache2_xdebug.ini.j2 dest=/etc/php/{{ php_version }}/mods-available/xdebug.ini
+  when: xdebug_installed.changed and vlad_os == 'ubuntu16'
   become: true


### PR DESCRIPTION
OK. This should fix things reasonably well. I'm not sure if Ubuntu 14.04 even supports PHP 7, or if we even support it in Vlad, but I don't think the cases that match that setup should fail. It'd fail much earlier than that, anyway. PHP 5.5/5.6 should also work on Ubuntu 16.04 now...at least Xdebug for them, assuming we have to fix them...

Only tested for `ubuntu16` + `7.0`