### PR TITLE
Fix db import up ansible 2.2

### DIFF
--- a/vlad_guts/playbooks/local_halt_destroy.yml
+++ b/vlad_guts/playbooks/local_halt_destroy.yml
@@ -32,7 +32,7 @@
       target: /var/www/site/vlad_aux/db_io/halt_destroy/{{ item }}.sql.gz
       login_user: root
       login_password: "{{ mysql_root_password }}"
-    with_items: dbname
+    with_items: '{{ dbname }}'
     when: mysql_install and vlad_db_dump_on_halt_destroy
     ignore_errors: yes
     become: true


### PR DESCRIPTION
Bare variables are treated as text now, so this broke auto-backup upon destroy!