### PR TITLE
Allow setting Vagrant mount options.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -281,7 +281,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       type: "smb",
       id: "vagrant-aux",
       smb_username: samba_username,
-      smb_password: samba_password
+      smb_password: samba_password,
+      mount_options: vconfig['vlad_synced_folder_mount_options']
 
   elsif synced_folder_type == 'nfs'
 
@@ -289,18 +290,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
 
     # Setup synced folder for site files
-    config.vm.synced_folder vconfig['host_synced_folder'], "/var/www/site/docroot", type: "nfs", nfs_udp: false, create: true, id: "vagrant-webroot"
+    config.vm.synced_folder vconfig['host_synced_folder'], "/var/www/site/docroot", type: "nfs", nfs_udp: false, create: true, id: "vagrant-webroot", mount_options: vconfig['vlad_synced_folder_mount_options']
 
     # Setup auxiliary synced folder
-    config.vm.synced_folder vconfig['aux_synced_folder'], "/var/www/site/vlad_aux", type: "nfs", nfs_udp: false, create: true, id: "vagrant-aux"
+    config.vm.synced_folder vconfig['aux_synced_folder'], "/var/www/site/vlad_aux", type: "nfs", nfs_udp: false, create: true, id: "vagrant-aux", mount_options: vconfig['vlad_synced_folder_mount_options']
 
   elsif synced_folder_type == 'rsync'
 
     # Setup synced folder for site files
-    config.vm.synced_folder vconfig['host_synced_folder'], "/var/www/site/docroot", type: "rsync", create: true, id: "vagrant-webroot"
+    config.vm.synced_folder vconfig['host_synced_folder'], "/var/www/site/docroot", type: "rsync", create: true, id: "vagrant-webroot", mount_options: vconfig['vlad_synced_folder_mount_options']
 
     # Setup auxiliary synced folder
-    config.vm.synced_folder vconfig['aux_synced_folder'], "/var/www/site/vlad_aux", type: "rsync", create: true, id: "vagrant-aux"
+    config.vm.synced_folder vconfig['aux_synced_folder'], "/var/www/site/vlad_aux", type: "rsync", create: true, id: "vagrant-aux", mount_options: vconfig['vlad_synced_folder_mount_options']
 
   else
 

--- a/vlad_guts/playbooks/vars/defaults/vagrant.yml
+++ b/vlad_guts/playbooks/vars/defaults/vagrant.yml
@@ -37,6 +37,9 @@ aux_synced_folder: "./vlad_aux"
 # Use 'nfs' or 'rsync' for VM file editing in synced folder
 synced_folder_type: 'nfs'
 
+# Set additional mount options.
+vlad_synced_folder_mount_options: '[]'
+
 # Set the level of verbosity that Ansible will use
 # This can be one of "", "v", "vv", "vvv", or "vvvv"
 ansible_verbosity: ""


### PR DESCRIPTION
I added this because I was trying to set the nolock mount option on my
NFS shares through Vagrant. Since I already added the setting, I figured
I would contribute it.

The setting doesn't do anything with the default value. This one overrides piecemeal rather than overriding the Vagrant defaults.